### PR TITLE
feat(messaging): add mq-bridge integration for unified messaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ members = [
     "armature-admin",
     "armature-payments",
     "armature-rhai",
+    "armature-siem",
 ]
 exclude = [
     "templates/*",

--- a/armature-messaging/Cargo.toml
+++ b/armature-messaging/Cargo.toml
@@ -18,6 +18,14 @@ rabbitmq = ["lapin"]
 kafka = ["rdkafka"]
 nats = ["async-nats"]
 aws = ["aws-config", "aws-sdk-sqs", "aws-sdk-sns"]
+# mq-bridge integration - provides unified messaging through mq-bridge crate
+mq-bridge = ["dep:mq-bridge", "dep:anyhow"]
+mq-bridge-kafka = ["mq-bridge", "mq-bridge/kafka"]
+mq-bridge-amqp = ["mq-bridge", "mq-bridge/amqp"]
+mq-bridge-nats = ["mq-bridge", "mq-bridge/nats"]
+mq-bridge-mqtt = ["mq-bridge", "mq-bridge/mqtt"]
+mq-bridge-http = ["mq-bridge", "mq-bridge/http"]
+mq-bridge-full = ["mq-bridge", "mq-bridge/full"]
 
 [dependencies]
 # Core
@@ -44,6 +52,10 @@ async-nats = { version = "0.45", optional = true }
 aws-config = { version = "1.5", optional = true }
 aws-sdk-sqs = { version = "1.50", optional = true }
 aws-sdk-sns = { version = "1.54", optional = true }
+
+# mq-bridge integration
+mq-bridge = { version = "0.1", optional = true }
+anyhow = { version = "1.0", optional = true }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/armature-messaging/src/lib.rs
+++ b/armature-messaging/src/lib.rs
@@ -67,6 +67,9 @@ pub mod nats;
 #[cfg(feature = "aws")]
 pub mod aws;
 
+#[cfg(feature = "mq-bridge")]
+pub mod mq_bridge;
+
 pub use config::*;
 pub use error::*;
 

--- a/armature-messaging/src/mq_bridge.rs
+++ b/armature-messaging/src/mq_bridge.rs
@@ -1,0 +1,750 @@
+//! mq-bridge integration for armature-messaging
+//!
+//! This module provides an adapter to use [mq-bridge](https://github.com/marcomq/mq-bridge)
+//! as a backend for armature-messaging. mq-bridge is a lower-level messaging library
+//! that focuses on data transport and provides unified access to Kafka, AMQP, NATS,
+//! MQTT, MongoDB, HTTP, and more.
+//!
+//! # Features
+//!
+//! The mq-bridge integration provides:
+//! - **Unified Transport Layer**: Use mq-bridge's `CanonicalMessage` for cross-protocol messaging
+//! - **Middleware Support**: Leverage mq-bridge's retry, DLQ, and deduplication middleware
+//! - **Route-based Architecture**: Define message routes with handlers and transformations
+//! - **Protocol Bridging**: Connect systems speaking different protocols (e.g., MQTT to Kafka)
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use armature_messaging::mq_bridge::*;
+//!
+//! // Create a memory-based broker for testing
+//! let broker = MqBridgeBroker::memory("test-channel").await?;
+//! broker.publish(Message::new("test", b"hello")).await?;
+//! ```
+//!
+//! # Integration with Armature Messaging
+//!
+//! The mq-bridge adapter implements the `MessageBroker` trait, allowing you to use
+//! mq-bridge endpoints seamlessly with the rest of armature-messaging:
+//!
+//! ```rust,ignore
+//! use armature_messaging::{MessageBroker, Message};
+//! use armature_messaging::mq_bridge::MqBridgeBroker;
+//!
+//! let broker = MqBridgeBroker::memory("test-channel").await?;
+//! broker.publish(Message::new("test", b"hello")).await?;
+//! ```
+
+use crate::{
+    Message, MessageBroker, MessageHandler, MessagingError, ProcessingResult,
+    PublishOptions, Subscription, SubscribeOptions,
+};
+use async_trait::async_trait;
+use mq_bridge::CanonicalMessage;
+use mq_bridge::endpoints::{create_consumer_from_route, create_publisher_from_route};
+use mq_bridge::models::{Endpoint, EndpointType, MemoryConfig, Route};
+use mq_bridge::traits::{Handler, MessageConsumer, MessagePublisher};
+use mq_bridge::{Handled, HandlerError};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// Configuration for mq-bridge endpoints
+#[derive(Debug, Clone)]
+pub struct MqBridgeConfig {
+    /// Endpoint type (kafka, amqp, nats, mqtt, http, memory, file)
+    pub endpoint_type: MqEndpointType,
+    /// Connection URL or configuration
+    pub url: String,
+    /// Topic/queue/subject name
+    pub topic: String,
+    /// Additional options
+    pub options: HashMap<String, String>,
+    /// Buffer size for memory endpoints
+    pub buffer_size: usize,
+}
+
+/// Supported mq-bridge endpoint types
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MqEndpointType {
+    /// In-memory channel (for testing)
+    Memory,
+    /// Apache Kafka
+    Kafka,
+    /// AMQP (RabbitMQ)
+    Amqp,
+    /// NATS
+    Nats,
+    /// MQTT
+    Mqtt,
+    /// HTTP
+    Http,
+    /// File-based
+    File,
+}
+
+impl Default for MqBridgeConfig {
+    fn default() -> Self {
+        Self {
+            endpoint_type: MqEndpointType::Memory,
+            url: String::new(),
+            topic: "default".to_string(),
+            options: HashMap::new(),
+            buffer_size: 1000,
+        }
+    }
+}
+
+impl MqBridgeConfig {
+    /// Create a new config for memory endpoint
+    pub fn memory(topic: impl Into<String>) -> Self {
+        Self {
+            endpoint_type: MqEndpointType::Memory,
+            topic: topic.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Create a new config for Kafka endpoint
+    #[cfg(feature = "mq-bridge-kafka")]
+    pub fn kafka(brokers: impl Into<String>, topic: impl Into<String>) -> Self {
+        Self {
+            endpoint_type: MqEndpointType::Kafka,
+            url: brokers.into(),
+            topic: topic.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Create a new config for AMQP endpoint
+    #[cfg(feature = "mq-bridge-amqp")]
+    pub fn amqp(url: impl Into<String>, queue: impl Into<String>) -> Self {
+        Self {
+            endpoint_type: MqEndpointType::Amqp,
+            url: url.into(),
+            topic: queue.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Create a new config for NATS endpoint
+    #[cfg(feature = "mq-bridge-nats")]
+    pub fn nats(url: impl Into<String>, subject: impl Into<String>) -> Self {
+        Self {
+            endpoint_type: MqEndpointType::Nats,
+            url: url.into(),
+            topic: subject.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Create a new config for MQTT endpoint
+    #[cfg(feature = "mq-bridge-mqtt")]
+    pub fn mqtt(url: impl Into<String>, topic: impl Into<String>) -> Self {
+        Self {
+            endpoint_type: MqEndpointType::Mqtt,
+            url: url.into(),
+            topic: topic.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Set buffer size (for memory endpoints)
+    pub fn with_buffer_size(mut self, size: usize) -> Self {
+        self.buffer_size = size;
+        self
+    }
+
+    /// Set a custom option
+    pub fn with_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.options.insert(key.into(), value.into());
+        self
+    }
+
+    /// Build an mq-bridge Endpoint from this config
+    pub fn build_endpoint(&self) -> Endpoint {
+        match self.endpoint_type {
+            MqEndpointType::Memory => Endpoint::new(EndpointType::Memory(MemoryConfig {
+                topic: self.topic.clone(),
+                capacity: Some(self.buffer_size),
+            })),
+            #[cfg(feature = "mq-bridge-kafka")]
+            MqEndpointType::Kafka => {
+                use mq_bridge::models::{KafkaConfig, KafkaEndpoint};
+                Endpoint::new(EndpointType::Kafka(KafkaEndpoint {
+                    topic: Some(self.topic.clone()),
+                    config: KafkaConfig {
+                        brokers: self.url.clone(),
+                        group_id: self.options.get("group_id").cloned(),
+                        ..Default::default()
+                    },
+                }))
+            }
+            #[cfg(not(feature = "mq-bridge-kafka"))]
+            MqEndpointType::Kafka => {
+                panic!("Kafka support requires 'mq-bridge-kafka' feature")
+            }
+            #[cfg(feature = "mq-bridge-amqp")]
+            MqEndpointType::Amqp => {
+                use mq_bridge::models::{AmqpConfig, AmqpEndpoint};
+                Endpoint::new(EndpointType::Amqp(AmqpEndpoint {
+                    queue: Some(self.topic.clone()),
+                    config: AmqpConfig {
+                        url: self.url.clone(),
+                        exchange: self.options.get("exchange").cloned(),
+                        ..Default::default()
+                    },
+                }))
+            }
+            #[cfg(not(feature = "mq-bridge-amqp"))]
+            MqEndpointType::Amqp => {
+                panic!("AMQP support requires 'mq-bridge-amqp' feature")
+            }
+            #[cfg(feature = "mq-bridge-nats")]
+            MqEndpointType::Nats => {
+                use mq_bridge::models::{NatsConfig, NatsEndpoint};
+                Endpoint::new(EndpointType::Nats(NatsEndpoint {
+                    subject: Some(self.topic.clone()),
+                    stream: self.options.get("stream").cloned(),
+                    config: NatsConfig {
+                        url: self.url.clone(),
+                        ..Default::default()
+                    },
+                }))
+            }
+            #[cfg(not(feature = "mq-bridge-nats"))]
+            MqEndpointType::Nats => {
+                panic!("NATS support requires 'mq-bridge-nats' feature")
+            }
+            #[cfg(feature = "mq-bridge-mqtt")]
+            MqEndpointType::Mqtt => {
+                use mq_bridge::models::{MqttConfig, MqttEndpoint};
+                Endpoint::new(EndpointType::Mqtt(MqttEndpoint {
+                    topic: Some(self.topic.clone()),
+                    config: MqttConfig {
+                        url: self.url.clone(),
+                        ..Default::default()
+                    },
+                }))
+            }
+            #[cfg(not(feature = "mq-bridge-mqtt"))]
+            MqEndpointType::Mqtt => {
+                panic!("MQTT support requires 'mq-bridge-mqtt' feature")
+            }
+            #[cfg(feature = "mq-bridge-http")]
+            MqEndpointType::Http => {
+                use mq_bridge::models::{HttpConfig, HttpEndpoint};
+                Endpoint::new(EndpointType::Http(HttpEndpoint {
+                    config: HttpConfig {
+                        url: Some(self.url.clone()),
+                        ..Default::default()
+                    },
+                }))
+            }
+            #[cfg(not(feature = "mq-bridge-http"))]
+            MqEndpointType::Http => {
+                panic!("HTTP support requires 'mq-bridge-http' feature")
+            }
+            MqEndpointType::File => {
+                Endpoint::new(EndpointType::File(self.topic.clone()))
+            }
+        }
+    }
+}
+
+/// Convert armature Message to mq-bridge CanonicalMessage
+pub fn to_canonical(msg: &Message) -> CanonicalMessage {
+    let mut canonical = CanonicalMessage::new(msg.payload.clone(), None);
+
+    // Store message ID in metadata
+    canonical.metadata.insert("armature_id".to_string(), msg.id.clone());
+    canonical.metadata.insert("armature_topic".to_string(), msg.topic.clone());
+
+    // Copy headers to metadata
+    for (key, value) in &msg.headers {
+        canonical.metadata.insert(key.clone(), value.clone());
+    }
+
+    if let Some(ref ct) = msg.content_type {
+        canonical.metadata.insert("content_type".to_string(), ct.clone());
+    }
+    if let Some(ref cid) = msg.correlation_id {
+        canonical.metadata.insert("correlation_id".to_string(), cid.clone());
+    }
+    if let Some(ref rt) = msg.reply_to {
+        canonical.metadata.insert("reply_to".to_string(), rt.clone());
+    }
+    if let Some(pri) = msg.priority {
+        canonical.metadata.insert("priority".to_string(), pri.to_string());
+    }
+    if let Some(ttl) = msg.ttl {
+        canonical.metadata.insert("ttl".to_string(), ttl.to_string());
+    }
+
+    canonical
+}
+
+/// Convert mq-bridge CanonicalMessage to armature Message
+pub fn from_canonical(canonical: CanonicalMessage, default_topic: &str) -> Message {
+    let topic = canonical.metadata
+        .get("armature_topic")
+        .cloned()
+        .unwrap_or_else(|| default_topic.to_string());
+
+    let mut msg = Message::new(topic, canonical.payload.to_vec());
+
+    // Restore message ID if present
+    if let Some(id) = canonical.metadata.get("armature_id") {
+        msg.id = id.clone();
+    }
+
+    // Restore optional fields from metadata
+    if let Some(ct) = canonical.metadata.get("content_type") {
+        msg.content_type = Some(ct.clone());
+    }
+    if let Some(cid) = canonical.metadata.get("correlation_id") {
+        msg.correlation_id = Some(cid.clone());
+    }
+    if let Some(rt) = canonical.metadata.get("reply_to") {
+        msg.reply_to = Some(rt.clone());
+    }
+    if let Some(pri) = canonical.metadata.get("priority") {
+        msg.priority = pri.parse().ok();
+    }
+    if let Some(ttl) = canonical.metadata.get("ttl") {
+        msg.ttl = ttl.parse().ok();
+    }
+
+    // Copy remaining metadata to headers (excluding reserved keys)
+    let reserved_keys = [
+        "armature_id", "armature_topic", "content_type",
+        "correlation_id", "reply_to", "priority", "ttl"
+    ];
+    for (key, value) in &canonical.metadata {
+        if !reserved_keys.contains(&key.as_str()) {
+            msg.headers.insert(key.clone(), value.clone());
+        }
+    }
+
+    msg
+}
+
+/// mq-bridge based message broker
+///
+/// This broker uses mq-bridge endpoints for message transport, providing
+/// access to Kafka, AMQP, NATS, MQTT, and more through a unified interface.
+pub struct MqBridgeBroker {
+    #[allow(dead_code)]
+    config: MqBridgeConfig,
+    endpoint: Endpoint,
+    route_name: String,
+    connected: AtomicBool,
+}
+
+impl MqBridgeBroker {
+    /// Create a new mq-bridge broker
+    pub async fn new(config: MqBridgeConfig) -> Result<Self, MessagingError> {
+        let endpoint = config.build_endpoint();
+        let route_name = format!("armature-{}", config.topic);
+
+        Ok(Self {
+            config,
+            endpoint,
+            route_name,
+            connected: AtomicBool::new(true),
+        })
+    }
+
+    /// Create a memory-based broker (for testing)
+    pub async fn memory(topic: impl Into<String>) -> Result<Self, MessagingError> {
+        Self::new(MqBridgeConfig::memory(topic)).await
+    }
+
+    /// Create a Kafka broker
+    #[cfg(feature = "mq-bridge-kafka")]
+    pub async fn kafka(
+        brokers: impl Into<String>,
+        topic: impl Into<String>,
+    ) -> Result<Self, MessagingError> {
+        Self::new(MqBridgeConfig::kafka(brokers, topic)).await
+    }
+
+    /// Create an AMQP broker
+    #[cfg(feature = "mq-bridge-amqp")]
+    pub async fn amqp(
+        url: impl Into<String>,
+        queue: impl Into<String>,
+    ) -> Result<Self, MessagingError> {
+        Self::new(MqBridgeConfig::amqp(url, queue)).await
+    }
+
+    /// Create a NATS broker
+    #[cfg(feature = "mq-bridge-nats")]
+    pub async fn nats(
+        url: impl Into<String>,
+        subject: impl Into<String>,
+    ) -> Result<Self, MessagingError> {
+        Self::new(MqBridgeConfig::nats(url, subject)).await
+    }
+
+    /// Get the underlying endpoint
+    pub fn endpoint(&self) -> &Endpoint {
+        &self.endpoint
+    }
+
+    /// Get the channel for memory endpoints (for testing)
+    pub fn channel(&self) -> Option<mq_bridge::endpoints::memory::MemoryChannel> {
+        self.endpoint.channel().ok()
+    }
+
+    async fn get_publisher(&self) -> Result<Arc<dyn MessagePublisher>, MessagingError> {
+        create_publisher_from_route(&self.route_name, &self.endpoint)
+            .await
+            .map_err(|e| MessagingError::Connection(e.to_string()))
+    }
+
+    async fn get_consumer(&self) -> Result<Box<dyn MessageConsumer>, MessagingError> {
+        create_consumer_from_route(&self.route_name, &self.endpoint)
+            .await
+            .map_err(|e| MessagingError::Connection(e.to_string()))
+    }
+}
+
+/// Subscription handle for mq-bridge
+pub struct MqBridgeSubscription {
+    topic: String,
+    active: AtomicBool,
+    cancel_token: tokio::sync::watch::Sender<bool>,
+}
+
+impl MqBridgeSubscription {
+    fn new(topic: String) -> (Self, tokio::sync::watch::Receiver<bool>) {
+        let (tx, rx) = tokio::sync::watch::channel(false);
+        (
+            Self {
+                topic,
+                active: AtomicBool::new(true),
+                cancel_token: tx,
+            },
+            rx,
+        )
+    }
+}
+
+#[async_trait]
+impl Subscription for MqBridgeSubscription {
+    async fn unsubscribe(&self) -> Result<(), MessagingError> {
+        self.active.store(false, Ordering::SeqCst);
+        let _ = self.cancel_token.send(true);
+        Ok(())
+    }
+
+    fn is_active(&self) -> bool {
+        self.active.load(Ordering::SeqCst)
+    }
+
+    fn topic(&self) -> &str {
+        &self.topic
+    }
+}
+
+/// Wrapper to adapt armature MessageHandler to mq-bridge Handler
+struct HandlerAdapter {
+    handler: Arc<dyn MessageHandler>,
+    topic: String,
+}
+
+#[async_trait]
+impl Handler for HandlerAdapter {
+    async fn handle(&self, msg: CanonicalMessage) -> Result<Handled, HandlerError> {
+        let armature_msg = from_canonical(msg, &self.topic);
+
+        match self.handler.handle(armature_msg).await {
+            Ok(ProcessingResult::Success) => Ok(Handled::Ack),
+            Ok(ProcessingResult::Retry) => Err(HandlerError::Retryable(
+                anyhow::anyhow!("Handler requested retry"),
+            )),
+            Ok(ProcessingResult::DeadLetter) => Err(HandlerError::NonRetryable(
+                anyhow::anyhow!("Handler requested dead-letter"),
+            )),
+            Ok(ProcessingResult::Reject) => Err(HandlerError::NonRetryable(
+                anyhow::anyhow!("Handler rejected message"),
+            )),
+            Err(e) => Err(HandlerError::NonRetryable(anyhow::anyhow!(
+                "Handler error: {}",
+                e
+            ))),
+        }
+    }
+}
+
+#[async_trait]
+impl MessageBroker for MqBridgeBroker {
+    type Subscription = MqBridgeSubscription;
+
+    async fn publish(&self, message: Message) -> Result<(), MessagingError> {
+        let publisher = self.get_publisher().await?;
+        let canonical = to_canonical(&message);
+
+        publisher
+            .send(canonical)
+            .await
+            .map_err(|e| MessagingError::Publish(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn publish_with_options(
+        &self,
+        message: Message,
+        _options: PublishOptions,
+    ) -> Result<(), MessagingError> {
+        // mq-bridge handles persistence and routing internally
+        self.publish(message).await
+    }
+
+    async fn subscribe(
+        &self,
+        topic: &str,
+        handler: Arc<dyn MessageHandler>,
+    ) -> Result<Self::Subscription, MessagingError> {
+        self.subscribe_with_options(topic, handler, SubscribeOptions::default())
+            .await
+    }
+
+    async fn subscribe_with_options(
+        &self,
+        topic: &str,
+        handler: Arc<dyn MessageHandler>,
+        _options: SubscribeOptions,
+    ) -> Result<Self::Subscription, MessagingError> {
+        let (subscription, mut cancel_rx) = MqBridgeSubscription::new(topic.to_string());
+
+        let mut consumer = self.get_consumer().await?;
+
+        let adapter = Arc::new(HandlerAdapter {
+            handler,
+            topic: topic.to_string(),
+        });
+
+        // Spawn consumer task
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = cancel_rx.changed() => {
+                        if *cancel_rx.borrow() {
+                            break;
+                        }
+                    }
+                    result = consumer.receive() => {
+                        match result {
+                            Ok(received) => {
+                                let msg = received.message;
+                                match adapter.handle(msg).await {
+                                    Ok(Handled::Ack) => {
+                                        (received.commit)(None).await;
+                                    }
+                                    Ok(Handled::Publish(response)) => {
+                                        (received.commit)(Some(response)).await;
+                                    }
+                                    Err(_) => {
+                                        // Error - don't commit, message will be redelivered
+                                    }
+                                }
+                            }
+                            Err(mq_bridge::errors::ConsumerError::EndOfStream) => {
+                                // Channel closed
+                                break;
+                            }
+                            Err(_) => {
+                                // Error - continue trying
+                                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(subscription)
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected.load(Ordering::SeqCst)
+    }
+
+    async fn close(&self) -> Result<(), MessagingError> {
+        self.connected.store(false, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+/// Helper to create message routes using mq-bridge
+///
+/// Routes define a pipeline from an input endpoint to an output endpoint
+/// with optional handlers and middleware.
+pub struct MqBridgeRoute {
+    input: Option<Endpoint>,
+    output: Option<Endpoint>,
+    handler: Option<Arc<dyn Handler>>,
+}
+
+impl MqBridgeRoute {
+    /// Create a new empty route
+    pub fn new() -> Self {
+        Self {
+            input: None,
+            output: None,
+            handler: None,
+        }
+    }
+
+    /// Set the input endpoint from config
+    pub fn from_config(mut self, config: MqBridgeConfig) -> Self {
+        self.input = Some(config.build_endpoint());
+        self
+    }
+
+    /// Set the output endpoint from config
+    pub fn to_config(mut self, config: MqBridgeConfig) -> Self {
+        self.output = Some(config.build_endpoint());
+        self
+    }
+
+    /// Set input from memory channel
+    pub fn from_memory(mut self, topic: impl Into<String>, buffer_size: usize) -> Self {
+        self.input = Some(Endpoint::new(EndpointType::Memory(MemoryConfig {
+            topic: topic.into(),
+            capacity: Some(buffer_size),
+        })));
+        self
+    }
+
+    /// Set output to memory channel
+    pub fn to_memory(mut self, topic: impl Into<String>, buffer_size: usize) -> Self {
+        self.output = Some(Endpoint::new(EndpointType::Memory(MemoryConfig {
+            topic: topic.into(),
+            capacity: Some(buffer_size),
+        })));
+        self
+    }
+
+    /// Set a handler function
+    pub fn with_handler<F, Fut>(mut self, f: F) -> Self
+    where
+        F: Fn(CanonicalMessage) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Result<Handled, HandlerError>> + Send + 'static,
+    {
+        self.handler = Some(Arc::new(FnHandlerWrapper(f)));
+        self
+    }
+
+    /// Build the mq-bridge Route
+    pub fn build(self) -> Result<Route, MessagingError> {
+        let input = self
+            .input
+            .ok_or_else(|| MessagingError::Configuration("Input endpoint not set".to_string()))?;
+        let mut output = self
+            .output
+            .ok_or_else(|| MessagingError::Configuration("Output endpoint not set".to_string()))?;
+
+        if let Some(handler) = self.handler {
+            output.handler = Some(handler);
+        }
+
+        Ok(Route {
+            input,
+            output,
+            concurrency: 1,
+            batch_size: 128,
+        })
+    }
+
+    /// Build and run the route
+    pub async fn run(self, name: &str) -> Result<(), MessagingError> {
+        let route = self.build()?;
+        route
+            .run_until_err(name, None, None)
+            .await
+            .map(|_| ())
+            .map_err(|e| MessagingError::Other(e.to_string()))
+    }
+}
+
+impl Default for MqBridgeRoute {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Wrapper for function handlers
+struct FnHandlerWrapper<F>(F);
+
+#[async_trait]
+impl<F, Fut> Handler for FnHandlerWrapper<F>
+where
+    F: Fn(CanonicalMessage) -> Fut + Send + Sync + 'static,
+    Fut: std::future::Future<Output = Result<Handled, HandlerError>> + Send + 'static,
+{
+    async fn handle(&self, msg: CanonicalMessage) -> Result<Handled, HandlerError> {
+        (self.0)(msg).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_memory() {
+        let config = MqBridgeConfig::memory("test-topic");
+        assert_eq!(config.endpoint_type, MqEndpointType::Memory);
+        assert_eq!(config.topic, "test-topic");
+    }
+
+    #[test]
+    fn test_message_conversion() {
+        let msg = Message::new("test-topic", b"hello world".to_vec())
+            .with_header("key", "value")
+            .with_correlation_id("corr-123");
+
+        let canonical = to_canonical(&msg);
+        assert_eq!(canonical.payload.as_ref(), b"hello world");
+        assert_eq!(
+            canonical.metadata.get("armature_topic"),
+            Some(&"test-topic".to_string())
+        );
+        assert_eq!(
+            canonical.metadata.get("key"),
+            Some(&"value".to_string())
+        );
+        assert_eq!(
+            canonical.metadata.get("correlation_id"),
+            Some(&"corr-123".to_string())
+        );
+
+        let back = from_canonical(canonical, "default");
+        assert_eq!(back.topic, "test-topic");
+        assert_eq!(back.payload, b"hello world");
+        assert_eq!(back.headers.get("key"), Some(&"value".to_string()));
+        assert_eq!(back.correlation_id, Some("corr-123".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_memory_broker() {
+        let broker = MqBridgeBroker::memory("test").await.unwrap();
+        assert!(broker.is_connected());
+
+        // Publish a message
+        let msg = Message::new("test", b"hello".to_vec());
+        broker.publish(msg).await.unwrap();
+
+        // Verify it was sent via the channel
+        if let Some(channel) = broker.channel() {
+            let msgs = channel.drain_messages();
+            assert_eq!(msgs.len(), 1);
+            assert_eq!(msgs[0].payload.as_ref(), b"hello");
+        }
+    }
+}

--- a/armature-siem/Cargo.toml
+++ b/armature-siem/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "armature-siem"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Enterprise SIEM integration for Armature - Splunk, Elastic, QRadar, Sentinel, and more"
+keywords = ["siem", "security", "logging", "splunk", "elastic"]
+categories = ["web-programming", "development-tools::debugging"]
+
+[dependencies]
+armature-core = { path = "../armature-core", version = "0.2.1", optional = true }
+armature-audit = { path = "../armature-audit", version = "0.1.1", optional = true }
+tokio = { version = "1.35", features = ["full"] }
+async-trait = "0.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1.11", features = ["v4", "serde"] }
+tracing = "0.1"
+thiserror = "2.0"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false, optional = true }
+url = "2.5"
+base64 = "0.22"
+hostname = "0.4"
+
+[dev-dependencies]
+tokio-test = "0.4"
+wiremock = "0.6"
+
+[features]
+default = []
+di = ["armature-core"]
+audit = ["armature-audit"]
+http = ["reqwest"]
+full = ["di", "audit", "http"]

--- a/armature-siem/src/client.rs
+++ b/armature-siem/src/client.rs
@@ -1,0 +1,404 @@
+//! SIEM client for sending events
+
+use crate::error::{SiemError, SiemResult};
+use crate::event::SiemEvent;
+use crate::format::{get_formatter, EventFormatter};
+use crate::config::{SiemConfig, Transport};
+use async_trait::async_trait;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Trait for SIEM transports
+#[async_trait]
+pub trait SiemTransport: Send + Sync {
+    /// Send formatted data to the SIEM
+    async fn send(&self, data: &str, content_type: &str) -> SiemResult<()>;
+
+    /// Close the transport connection
+    async fn close(&self) -> SiemResult<()>;
+}
+
+/// SIEM client for sending security events
+///
+/// # Examples
+///
+/// ```no_run
+/// use armature_siem::*;
+///
+/// # async fn example() -> Result<(), SiemError> {
+/// let config = SiemConfig::builder()
+///     .provider(SiemProvider::Splunk)
+///     .endpoint("https://splunk.example.com:8088/services/collector")
+///     .token("your-hec-token")
+///     .build()?;
+///
+/// let client = SiemClient::new(config)?;
+///
+/// client.send(SiemEvent::new("user.login")
+///     .src_user("alice")
+///     .src_ip("192.168.1.100")
+///     .action("login")
+///     .outcome(EventOutcome::Success)).await?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct SiemClient {
+    config: SiemConfig,
+    formatter: Box<dyn EventFormatter>,
+    transport: Arc<dyn SiemTransport>,
+    batch: Arc<Mutex<Vec<SiemEvent>>>,
+}
+
+impl SiemClient {
+    /// Create a new SIEM client
+    pub fn new(config: SiemConfig) -> SiemResult<Self> {
+        config.validate()?;
+
+        let formatter = get_formatter(config.format);
+        let transport: Arc<dyn SiemTransport> = match config.transport {
+            Transport::Https => {
+                #[cfg(feature = "http")]
+                {
+                    Arc::new(HttpTransport::new(&config)?)
+                }
+                #[cfg(not(feature = "http"))]
+                {
+                    return Err(SiemError::Config(
+                        "HTTP transport requires 'http' feature".to_string(),
+                    ));
+                }
+            }
+            Transport::Tcp | Transport::Tls => {
+                Arc::new(TcpTransport::new(&config)?)
+            }
+            Transport::Udp => {
+                Arc::new(UdpTransport::new(&config)?)
+            }
+        };
+
+        Ok(Self {
+            config,
+            formatter,
+            transport,
+            batch: Arc::new(Mutex::new(Vec::new())),
+        })
+    }
+
+    /// Send a single event immediately
+    pub async fn send(&self, event: SiemEvent) -> SiemResult<()> {
+        if self.config.batching_enabled {
+            self.add_to_batch(event).await
+        } else {
+            self.send_immediate(event).await
+        }
+    }
+
+    /// Send multiple events
+    pub async fn send_many(&self, events: Vec<SiemEvent>) -> SiemResult<()> {
+        if self.config.batching_enabled {
+            for event in events {
+                self.add_to_batch(event).await?;
+            }
+            Ok(())
+        } else {
+            let formatted = self.formatter.format_batch(&events, &self.config)?;
+            self.transport
+                .send(&formatted, self.formatter.content_type())
+                .await
+        }
+    }
+
+    /// Send an event immediately (bypassing batch)
+    pub async fn send_immediate(&self, event: SiemEvent) -> SiemResult<()> {
+        let formatted = self.formatter.format(&event, &self.config)?;
+        self.transport
+            .send(&formatted, self.formatter.content_type())
+            .await
+    }
+
+    /// Add event to batch, flushing if full
+    async fn add_to_batch(&self, event: SiemEvent) -> SiemResult<()> {
+        let mut batch = self.batch.lock().await;
+        batch.push(event);
+
+        if batch.len() >= self.config.batch_size {
+            let events = std::mem::take(&mut *batch);
+            drop(batch);
+            self.flush_events(events).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Flush the current batch
+    pub async fn flush(&self) -> SiemResult<()> {
+        let events = {
+            let mut batch = self.batch.lock().await;
+            std::mem::take(&mut *batch)
+        };
+
+        if !events.is_empty() {
+            self.flush_events(events).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Flush specific events
+    async fn flush_events(&self, events: Vec<SiemEvent>) -> SiemResult<()> {
+        let formatted = self.formatter.format_batch(&events, &self.config)?;
+        self.transport
+            .send(&formatted, self.formatter.content_type())
+            .await
+    }
+
+    /// Close the client and flush remaining events
+    pub async fn close(&self) -> SiemResult<()> {
+        self.flush().await?;
+        self.transport.close().await
+    }
+
+    /// Get the current batch size
+    pub async fn batch_len(&self) -> usize {
+        self.batch.lock().await.len()
+    }
+}
+
+/// HTTP transport (for Splunk HEC, Elastic, Sentinel, etc.)
+#[cfg(feature = "http")]
+pub struct HttpTransport {
+    client: reqwest::Client,
+    endpoint: String,
+    auth_header: Option<String>,
+}
+
+#[cfg(feature = "http")]
+impl HttpTransport {
+    /// Create a new HTTP transport
+    pub fn new(config: &SiemConfig) -> SiemResult<Self> {
+        let mut builder = reqwest::Client::builder()
+            .connect_timeout(config.connect_timeout)
+            .timeout(config.request_timeout);
+
+        if !config.tls_verify {
+            builder = builder.danger_accept_invalid_certs(true);
+        }
+
+        // Note: Compression is handled via headers, not client builder
+        let _ = config.compression; // Used in request headers if needed
+
+        let client = builder.build()?;
+
+        // Build auth header based on provider
+        let auth_header = match config.provider {
+            crate::SiemProvider::Splunk => {
+                config.token.as_ref().map(|t| format!("Splunk {}", t))
+            }
+            crate::SiemProvider::Elastic | crate::SiemProvider::Datadog => {
+                config.token.as_ref().map(|t| format!("Bearer {}", t))
+            }
+            crate::SiemProvider::Sentinel => {
+                // Azure Sentinel uses SharedKey authentication
+                config.token.clone()
+            }
+            crate::SiemProvider::SumoLogic => {
+                // Sumo Logic uses the token in the URL or as header
+                config.token.clone()
+            }
+            _ => {
+                // Generic: check for basic auth or token
+                if let (Some(user), Some(pass)) = (&config.username, &config.password) {
+                    let encoded = base64::Engine::encode(
+                        &base64::engine::general_purpose::STANDARD,
+                        format!("{}:{}", user, pass),
+                    );
+                    Some(format!("Basic {}", encoded))
+                } else {
+                    config.token.as_ref().map(|t| format!("Bearer {}", t))
+                }
+            }
+        };
+
+        Ok(Self {
+            client,
+            endpoint: config.endpoint.clone(),
+            auth_header,
+        })
+    }
+}
+
+#[cfg(feature = "http")]
+#[async_trait]
+impl SiemTransport for HttpTransport {
+    async fn send(&self, data: &str, content_type: &str) -> SiemResult<()> {
+        let mut request = self
+            .client
+            .post(&self.endpoint)
+            .header("Content-Type", content_type)
+            .body(data.to_string());
+
+        if let Some(ref auth) = self.auth_header {
+            request = request.header("Authorization", auth);
+        }
+
+        let response = request.send().await?;
+        let status = response.status();
+
+        if status.is_success() {
+            Ok(())
+        } else if status.as_u16() == 429 {
+            // Rate limited
+            let retry_after = response
+                .headers()
+                .get("Retry-After")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(1000);
+            Err(SiemError::RateLimited(retry_after))
+        } else if status.as_u16() == 401 || status.as_u16() == 403 {
+            Err(SiemError::Auth(format!("Authentication failed: {}", status)))
+        } else {
+            let body = response.text().await.unwrap_or_default();
+            Err(SiemError::Transport(format!(
+                "HTTP {} - {}",
+                status, body
+            )))
+        }
+    }
+
+    async fn close(&self) -> SiemResult<()> {
+        Ok(())
+    }
+}
+
+/// TCP transport (for Syslog, QRadar, ArcSight)
+pub struct TcpTransport {
+    endpoint: String,
+    tls: bool,
+}
+
+impl TcpTransport {
+    /// Create a new TCP transport
+    pub fn new(config: &SiemConfig) -> SiemResult<Self> {
+        Ok(Self {
+            endpoint: config.endpoint.clone(),
+            tls: config.transport == Transport::Tls,
+        })
+    }
+}
+
+#[async_trait]
+impl SiemTransport for TcpTransport {
+    async fn send(&self, data: &str, _content_type: &str) -> SiemResult<()> {
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpStream;
+
+        let mut stream = TcpStream::connect(&self.endpoint).await?;
+
+        // For TLS, we would wrap with TLS here
+        // For now, plain TCP
+        if self.tls {
+            tracing::warn!("TLS transport requested but not fully implemented, using plain TCP");
+        }
+
+        stream.write_all(data.as_bytes()).await?;
+        stream.write_all(b"\n").await?;
+        stream.flush().await?;
+
+        Ok(())
+    }
+
+    async fn close(&self) -> SiemResult<()> {
+        Ok(())
+    }
+}
+
+/// UDP transport (for Syslog)
+pub struct UdpTransport {
+    endpoint: String,
+}
+
+impl UdpTransport {
+    /// Create a new UDP transport
+    pub fn new(config: &SiemConfig) -> SiemResult<Self> {
+        Ok(Self {
+            endpoint: config.endpoint.clone(),
+        })
+    }
+}
+
+#[async_trait]
+impl SiemTransport for UdpTransport {
+    async fn send(&self, data: &str, _content_type: &str) -> SiemResult<()> {
+        use tokio::net::UdpSocket;
+
+        let socket = UdpSocket::bind("0.0.0.0:0").await?;
+        socket.connect(&self.endpoint).await?;
+        socket.send(data.as_bytes()).await?;
+
+        Ok(())
+    }
+
+    async fn close(&self) -> SiemResult<()> {
+        Ok(())
+    }
+}
+
+/// Memory transport for testing
+pub struct MemoryTransport {
+    messages: Arc<Mutex<Vec<String>>>,
+}
+
+impl MemoryTransport {
+    /// Create a new memory transport
+    pub fn new() -> Self {
+        Self {
+            messages: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Get all sent messages
+    pub async fn get_messages(&self) -> Vec<String> {
+        self.messages.lock().await.clone()
+    }
+
+    /// Clear messages
+    pub async fn clear(&self) {
+        self.messages.lock().await.clear();
+    }
+}
+
+impl Default for MemoryTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SiemTransport for MemoryTransport {
+    async fn send(&self, data: &str, _content_type: &str) -> SiemResult<()> {
+        self.messages.lock().await.push(data.to_string());
+        Ok(())
+    }
+
+    async fn close(&self) -> SiemResult<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_memory_transport() {
+        let transport = MemoryTransport::new();
+
+        transport.send("test message", "text/plain").await.unwrap();
+        transport.send("second message", "text/plain").await.unwrap();
+
+        let messages = transport.get_messages().await;
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0], "test message");
+    }
+}

--- a/armature-siem/src/config.rs
+++ b/armature-siem/src/config.rs
@@ -1,0 +1,471 @@
+//! SIEM configuration with builder pattern
+
+use crate::error::SiemError;
+use std::time::Duration;
+
+/// SIEM provider type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SiemProvider {
+    /// Splunk Enterprise / Cloud
+    Splunk,
+    /// Elasticsearch / Elastic Security
+    Elastic,
+    /// IBM QRadar
+    QRadar,
+    /// Microsoft Sentinel
+    Sentinel,
+    /// Sumo Logic
+    SumoLogic,
+    /// Datadog Security
+    Datadog,
+    /// LogRhythm
+    LogRhythm,
+    /// ArcSight (Micro Focus)
+    ArcSight,
+    /// Generic Syslog
+    Syslog,
+    /// Custom/Generic HTTPS endpoint
+    Custom,
+}
+
+impl std::fmt::Display for SiemProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SiemProvider::Splunk => write!(f, "Splunk"),
+            SiemProvider::Elastic => write!(f, "Elastic"),
+            SiemProvider::QRadar => write!(f, "QRadar"),
+            SiemProvider::Sentinel => write!(f, "Sentinel"),
+            SiemProvider::SumoLogic => write!(f, "SumoLogic"),
+            SiemProvider::Datadog => write!(f, "Datadog"),
+            SiemProvider::LogRhythm => write!(f, "LogRhythm"),
+            SiemProvider::ArcSight => write!(f, "ArcSight"),
+            SiemProvider::Syslog => write!(f, "Syslog"),
+            SiemProvider::Custom => write!(f, "Custom"),
+        }
+    }
+}
+
+/// Event format for SIEM systems
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EventFormat {
+    /// JSON format (most flexible)
+    #[default]
+    Json,
+    /// Common Event Format (ArcSight, Splunk, etc.)
+    Cef,
+    /// Log Event Extended Format (IBM QRadar)
+    Leef,
+    /// Syslog RFC 5424
+    Syslog,
+    /// Elastic Common Schema
+    Ecs,
+}
+
+impl std::fmt::Display for EventFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EventFormat::Json => write!(f, "JSON"),
+            EventFormat::Cef => write!(f, "CEF"),
+            EventFormat::Leef => write!(f, "LEEF"),
+            EventFormat::Syslog => write!(f, "Syslog"),
+            EventFormat::Ecs => write!(f, "ECS"),
+        }
+    }
+}
+
+/// Transport protocol
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Transport {
+    /// HTTPS (HTTP Event Collector, etc.)
+    #[default]
+    Https,
+    /// TCP
+    Tcp,
+    /// UDP
+    Udp,
+    /// TLS over TCP
+    Tls,
+}
+
+/// Syslog facility
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SyslogFacility {
+    Kern = 0,
+    User = 1,
+    Mail = 2,
+    Daemon = 3,
+    Auth = 4,
+    Syslog = 5,
+    Lpr = 6,
+    News = 7,
+    Uucp = 8,
+    Cron = 9,
+    Authpriv = 10,
+    Ftp = 11,
+    Local0 = 16,
+    Local1 = 17,
+    Local2 = 18,
+    Local3 = 19,
+    Local4 = 20,
+    Local5 = 21,
+    Local6 = 22,
+    Local7 = 23,
+}
+
+impl Default for SyslogFacility {
+    fn default() -> Self {
+        SyslogFacility::Local0
+    }
+}
+
+/// SIEM client configuration
+#[derive(Debug, Clone)]
+pub struct SiemConfig {
+    /// Target SIEM provider
+    pub provider: SiemProvider,
+    /// Endpoint URL or host:port
+    pub endpoint: String,
+    /// Event format
+    pub format: EventFormat,
+    /// Transport protocol
+    pub transport: Transport,
+    /// Authentication token (HEC token, API key, etc.)
+    pub token: Option<String>,
+    /// Username for basic auth
+    pub username: Option<String>,
+    /// Password for basic auth
+    pub password: Option<String>,
+    /// Index/source for events (Splunk index, Elastic index, etc.)
+    pub index: Option<String>,
+    /// Source type (for Splunk)
+    pub source_type: Option<String>,
+    /// Source (for Splunk/CEF)
+    pub source: Option<String>,
+    /// Connection timeout
+    pub connect_timeout: Duration,
+    /// Request timeout
+    pub request_timeout: Duration,
+    /// Enable batching
+    pub batching_enabled: bool,
+    /// Batch size (number of events)
+    pub batch_size: usize,
+    /// Batch flush interval
+    pub batch_flush_interval: Duration,
+    /// Enable TLS certificate verification
+    pub tls_verify: bool,
+    /// Custom CA certificate path
+    pub ca_cert_path: Option<String>,
+    /// Syslog facility (for Syslog format)
+    pub syslog_facility: SyslogFacility,
+    /// Application name (for Syslog/CEF)
+    pub app_name: String,
+    /// CEF vendor name
+    pub cef_vendor: String,
+    /// CEF product name
+    pub cef_product: String,
+    /// CEF product version
+    pub cef_version: String,
+    /// Enable compression (gzip)
+    pub compression: bool,
+    /// Max retries on failure
+    pub max_retries: u32,
+    /// Retry delay
+    pub retry_delay: Duration,
+}
+
+impl Default for SiemConfig {
+    fn default() -> Self {
+        Self {
+            provider: SiemProvider::Splunk,
+            endpoint: String::new(),
+            format: EventFormat::Json,
+            transport: Transport::Https,
+            token: None,
+            username: None,
+            password: None,
+            index: None,
+            source_type: None,
+            source: None,
+            connect_timeout: Duration::from_secs(10),
+            request_timeout: Duration::from_secs(30),
+            batching_enabled: true,
+            batch_size: 100,
+            batch_flush_interval: Duration::from_secs(5),
+            tls_verify: true,
+            ca_cert_path: None,
+            syslog_facility: SyslogFacility::default(),
+            app_name: "armature".to_string(),
+            cef_vendor: "Armature".to_string(),
+            cef_product: "ArmatureFramework".to_string(),
+            cef_version: "1.0".to_string(),
+            compression: false,
+            max_retries: 3,
+            retry_delay: Duration::from_millis(1000),
+        }
+    }
+}
+
+impl SiemConfig {
+    /// Create a new config builder
+    pub fn builder() -> SiemConfigBuilder {
+        SiemConfigBuilder::default()
+    }
+
+    /// Validate the configuration
+    pub fn validate(&self) -> Result<(), SiemError> {
+        if self.endpoint.is_empty() {
+            return Err(SiemError::Config("Endpoint is required".to_string()));
+        }
+
+        // Validate transport/endpoint combinations
+        match self.transport {
+            Transport::Https => {
+                if !self.endpoint.starts_with("http://") && !self.endpoint.starts_with("https://") {
+                    return Err(SiemError::Config(
+                        "HTTPS transport requires http:// or https:// endpoint".to_string(),
+                    ));
+                }
+            }
+            Transport::Tcp | Transport::Udp | Transport::Tls => {
+                // Should be host:port format
+                if !self.endpoint.contains(':') {
+                    return Err(SiemError::Config(
+                        "TCP/UDP transport requires host:port format".to_string(),
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Builder for SIEM configuration
+#[derive(Default)]
+pub struct SiemConfigBuilder {
+    config: SiemConfig,
+}
+
+impl SiemConfigBuilder {
+    /// Set the SIEM provider
+    pub fn provider(mut self, provider: SiemProvider) -> Self {
+        self.config.provider = provider;
+        // Set sensible defaults based on provider
+        match provider {
+            SiemProvider::Splunk => {
+                self.config.format = EventFormat::Json;
+                self.config.transport = Transport::Https;
+            }
+            SiemProvider::Elastic => {
+                self.config.format = EventFormat::Ecs;
+                self.config.transport = Transport::Https;
+            }
+            SiemProvider::QRadar => {
+                self.config.format = EventFormat::Leef;
+                self.config.transport = Transport::Tcp;
+            }
+            SiemProvider::Sentinel => {
+                self.config.format = EventFormat::Json;
+                self.config.transport = Transport::Https;
+            }
+            SiemProvider::ArcSight => {
+                self.config.format = EventFormat::Cef;
+                self.config.transport = Transport::Tcp;
+            }
+            SiemProvider::Syslog => {
+                self.config.format = EventFormat::Syslog;
+                self.config.transport = Transport::Udp;
+            }
+            _ => {}
+        }
+        self
+    }
+
+    /// Set the endpoint URL or host:port
+    pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.config.endpoint = endpoint.into();
+        self
+    }
+
+    /// Set the event format
+    pub fn format(mut self, format: EventFormat) -> Self {
+        self.config.format = format;
+        self
+    }
+
+    /// Set the transport protocol
+    pub fn transport(mut self, transport: Transport) -> Self {
+        self.config.transport = transport;
+        self
+    }
+
+    /// Set the authentication token
+    pub fn token(mut self, token: impl Into<String>) -> Self {
+        self.config.token = Some(token.into());
+        self
+    }
+
+    /// Set basic auth credentials
+    pub fn basic_auth(mut self, username: impl Into<String>, password: impl Into<String>) -> Self {
+        self.config.username = Some(username.into());
+        self.config.password = Some(password.into());
+        self
+    }
+
+    /// Set the index/source
+    pub fn index(mut self, index: impl Into<String>) -> Self {
+        self.config.index = Some(index.into());
+        self
+    }
+
+    /// Set the source type (Splunk)
+    pub fn source_type(mut self, source_type: impl Into<String>) -> Self {
+        self.config.source_type = Some(source_type.into());
+        self
+    }
+
+    /// Set the source (Splunk/CEF)
+    pub fn source(mut self, source: impl Into<String>) -> Self {
+        self.config.source = Some(source.into());
+        self
+    }
+
+    /// Set connection timeout
+    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
+        self.config.connect_timeout = timeout;
+        self
+    }
+
+    /// Set request timeout
+    pub fn request_timeout(mut self, timeout: Duration) -> Self {
+        self.config.request_timeout = timeout;
+        self
+    }
+
+    /// Enable/disable batching
+    pub fn batching(mut self, enabled: bool) -> Self {
+        self.config.batching_enabled = enabled;
+        self
+    }
+
+    /// Set batch size
+    pub fn batch_size(mut self, size: usize) -> Self {
+        self.config.batch_size = size;
+        self
+    }
+
+    /// Set batch flush interval
+    pub fn batch_flush_interval(mut self, interval: Duration) -> Self {
+        self.config.batch_flush_interval = interval;
+        self
+    }
+
+    /// Enable/disable TLS verification
+    pub fn tls_verify(mut self, verify: bool) -> Self {
+        self.config.tls_verify = verify;
+        self
+    }
+
+    /// Set custom CA certificate path
+    pub fn ca_cert(mut self, path: impl Into<String>) -> Self {
+        self.config.ca_cert_path = Some(path.into());
+        self
+    }
+
+    /// Set syslog facility
+    pub fn syslog_facility(mut self, facility: SyslogFacility) -> Self {
+        self.config.syslog_facility = facility;
+        self
+    }
+
+    /// Set application name
+    pub fn app_name(mut self, name: impl Into<String>) -> Self {
+        self.config.app_name = name.into();
+        self
+    }
+
+    /// Set CEF vendor
+    pub fn cef_vendor(mut self, vendor: impl Into<String>) -> Self {
+        self.config.cef_vendor = vendor.into();
+        self
+    }
+
+    /// Set CEF product
+    pub fn cef_product(mut self, product: impl Into<String>) -> Self {
+        self.config.cef_product = product.into();
+        self
+    }
+
+    /// Set CEF version
+    pub fn cef_version(mut self, version: impl Into<String>) -> Self {
+        self.config.cef_version = version.into();
+        self
+    }
+
+    /// Enable/disable compression
+    pub fn compression(mut self, enabled: bool) -> Self {
+        self.config.compression = enabled;
+        self
+    }
+
+    /// Set max retries
+    pub fn max_retries(mut self, retries: u32) -> Self {
+        self.config.max_retries = retries;
+        self
+    }
+
+    /// Set retry delay
+    pub fn retry_delay(mut self, delay: Duration) -> Self {
+        self.config.retry_delay = delay;
+        self
+    }
+
+    /// Build the configuration
+    pub fn build(self) -> Result<SiemConfig, SiemError> {
+        self.config.validate()?;
+        Ok(self.config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_builder() {
+        let config = SiemConfig::builder()
+            .provider(SiemProvider::Splunk)
+            .endpoint("https://splunk.example.com:8088")
+            .token("my-hec-token")
+            .index("security")
+            .build()
+            .unwrap();
+
+        assert_eq!(config.provider, SiemProvider::Splunk);
+        assert_eq!(config.endpoint, "https://splunk.example.com:8088");
+        assert_eq!(config.token, Some("my-hec-token".to_string()));
+        assert_eq!(config.index, Some("security".to_string()));
+    }
+
+    #[test]
+    fn test_config_validation_empty_endpoint() {
+        let result = SiemConfig::builder()
+            .provider(SiemProvider::Splunk)
+            .build();
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_provider_defaults() {
+        let config = SiemConfig::builder()
+            .provider(SiemProvider::QRadar)
+            .endpoint("qradar.example.com:514")
+            .build()
+            .unwrap();
+
+        assert_eq!(config.format, EventFormat::Leef);
+        assert_eq!(config.transport, Transport::Tcp);
+    }
+}

--- a/armature-siem/src/error.rs
+++ b/armature-siem/src/error.rs
@@ -1,0 +1,63 @@
+//! SIEM error types
+
+use thiserror::Error;
+
+/// SIEM-related errors
+#[derive(Error, Debug)]
+pub enum SiemError {
+    /// Configuration error
+    #[error("Configuration error: {0}")]
+    Config(String),
+
+    /// Connection error
+    #[error("Connection failed: {0}")]
+    Connection(String),
+
+    /// Transport error (sending events)
+    #[error("Transport error: {0}")]
+    Transport(String),
+
+    /// Serialization error
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    /// HTTP error (for HEC endpoints)
+    #[cfg(feature = "http")]
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// IO error
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// URL parse error
+    #[error("Invalid URL: {0}")]
+    UrlParse(#[from] url::ParseError),
+
+    /// Authentication error
+    #[error("Authentication failed: {0}")]
+    Auth(String),
+
+    /// Rate limited
+    #[error("Rate limited, retry after: {0}ms")]
+    RateLimited(u64),
+
+    /// Provider not supported
+    #[error("Provider not supported: {0}")]
+    UnsupportedProvider(String),
+
+    /// Format not supported
+    #[error("Format not supported: {0}")]
+    UnsupportedFormat(String),
+
+    /// Batch full
+    #[error("Batch is full, max size: {0}")]
+    BatchFull(usize),
+
+    /// Timeout
+    #[error("Operation timed out after {0}ms")]
+    Timeout(u64),
+}
+
+/// Result type for SIEM operations
+pub type SiemResult<T> = Result<T, SiemError>;

--- a/armature-siem/src/event.rs
+++ b/armature-siem/src/event.rs
@@ -1,0 +1,677 @@
+//! SIEM event types and structures
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// Severity level for SIEM events
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum SiemSeverity {
+    /// Unknown severity (0)
+    Unknown = 0,
+    /// Low severity (1-3)
+    Low = 1,
+    /// Medium severity (4-6)
+    Medium = 4,
+    /// High severity (7-8)
+    High = 7,
+    /// Critical severity (9-10)
+    Critical = 9,
+}
+
+impl SiemSeverity {
+    /// Get numeric value (0-10 scale for CEF)
+    pub fn as_cef_severity(&self) -> u8 {
+        match self {
+            SiemSeverity::Unknown => 0,
+            SiemSeverity::Low => 3,
+            SiemSeverity::Medium => 5,
+            SiemSeverity::High => 8,
+            SiemSeverity::Critical => 10,
+        }
+    }
+
+    /// Get syslog severity (0-7)
+    pub fn as_syslog_severity(&self) -> u8 {
+        match self {
+            SiemSeverity::Unknown => 6,  // Informational
+            SiemSeverity::Low => 5,      // Notice
+            SiemSeverity::Medium => 4,   // Warning
+            SiemSeverity::High => 3,     // Error
+            SiemSeverity::Critical => 2, // Critical
+        }
+    }
+}
+
+impl Default for SiemSeverity {
+    fn default() -> Self {
+        SiemSeverity::Unknown
+    }
+}
+
+/// Event outcome
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EventOutcome {
+    /// Operation succeeded
+    Success,
+    /// Operation failed
+    Failure,
+    /// Outcome unknown
+    Unknown,
+}
+
+impl Default for EventOutcome {
+    fn default() -> Self {
+        EventOutcome::Unknown
+    }
+}
+
+/// Event category (aligned with ECS categories)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventCategory {
+    /// Authentication events
+    Authentication,
+    /// Authorization events
+    Authorization,
+    /// Configuration changes
+    Configuration,
+    /// Database activity
+    Database,
+    /// File system activity
+    File,
+    /// Host activity
+    Host,
+    /// IAM activity
+    Iam,
+    /// Intrusion detection
+    IntrusionDetection,
+    /// Malware activity
+    Malware,
+    /// Network activity
+    Network,
+    /// Package management
+    Package,
+    /// Process activity
+    Process,
+    /// Registry activity
+    Registry,
+    /// Session activity
+    Session,
+    /// Threat intelligence
+    Threat,
+    /// Vulnerability
+    Vulnerability,
+    /// Web activity
+    Web,
+    /// Custom category
+    Custom(String),
+}
+
+impl Default for EventCategory {
+    fn default() -> Self {
+        EventCategory::Web
+    }
+}
+
+impl std::fmt::Display for EventCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EventCategory::Authentication => write!(f, "authentication"),
+            EventCategory::Authorization => write!(f, "authorization"),
+            EventCategory::Configuration => write!(f, "configuration"),
+            EventCategory::Database => write!(f, "database"),
+            EventCategory::File => write!(f, "file"),
+            EventCategory::Host => write!(f, "host"),
+            EventCategory::Iam => write!(f, "iam"),
+            EventCategory::IntrusionDetection => write!(f, "intrusion_detection"),
+            EventCategory::Malware => write!(f, "malware"),
+            EventCategory::Network => write!(f, "network"),
+            EventCategory::Package => write!(f, "package"),
+            EventCategory::Process => write!(f, "process"),
+            EventCategory::Registry => write!(f, "registry"),
+            EventCategory::Session => write!(f, "session"),
+            EventCategory::Threat => write!(f, "threat"),
+            EventCategory::Vulnerability => write!(f, "vulnerability"),
+            EventCategory::Web => write!(f, "web"),
+            EventCategory::Custom(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+/// SIEM event structure
+///
+/// A normalized event structure that can be converted to various SIEM formats.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SiemEvent {
+    /// Unique event ID
+    pub id: String,
+
+    /// Timestamp when event occurred
+    pub timestamp: DateTime<Utc>,
+
+    /// Event type/name (e.g., "user.login", "file.access")
+    pub event_type: String,
+
+    /// Event category
+    pub category: EventCategory,
+
+    /// Severity level
+    pub severity: SiemSeverity,
+
+    /// Event outcome
+    pub outcome: EventOutcome,
+
+    /// Event action (e.g., "login", "logout", "create", "delete")
+    pub action: String,
+
+    /// Event message/description
+    pub message: Option<String>,
+
+    // Source information
+    /// Source IP address
+    pub src_ip: Option<String>,
+    /// Source port
+    pub src_port: Option<u16>,
+    /// Source hostname
+    pub src_host: Option<String>,
+    /// Source user
+    pub src_user: Option<String>,
+    /// Source process
+    pub src_process: Option<String>,
+
+    // Destination information
+    /// Destination IP address
+    pub dst_ip: Option<String>,
+    /// Destination port
+    pub dst_port: Option<u16>,
+    /// Destination hostname
+    pub dst_host: Option<String>,
+    /// Destination user
+    pub dst_user: Option<String>,
+
+    // Request information (for web events)
+    /// HTTP method
+    pub http_method: Option<String>,
+    /// Request URL/path
+    pub url: Option<String>,
+    /// User agent
+    pub user_agent: Option<String>,
+    /// HTTP status code
+    pub http_status: Option<u16>,
+    /// Request/response size in bytes
+    pub bytes: Option<u64>,
+
+    // Resource information
+    /// Resource type being accessed
+    pub resource_type: Option<String>,
+    /// Resource identifier
+    pub resource_id: Option<String>,
+    /// Resource name
+    pub resource_name: Option<String>,
+
+    // Application context
+    /// Application name
+    pub application: Option<String>,
+    /// Service name
+    pub service: Option<String>,
+    /// Environment (prod, staging, dev)
+    pub environment: Option<String>,
+
+    // Error information
+    /// Error code
+    pub error_code: Option<String>,
+    /// Error message
+    pub error_message: Option<String>,
+
+    // Duration
+    /// Event duration in milliseconds
+    pub duration_ms: Option<u64>,
+
+    // Protocol information
+    /// Network protocol
+    pub protocol: Option<String>,
+
+    // Device information
+    /// Device ID
+    pub device_id: Option<String>,
+    /// Device type
+    pub device_type: Option<String>,
+
+    // Threat information
+    /// Threat indicator type
+    pub threat_indicator_type: Option<String>,
+    /// Threat indicator value
+    pub threat_indicator: Option<String>,
+
+    // File information (for file events)
+    /// File path
+    pub file_path: Option<String>,
+    /// File hash
+    pub file_hash: Option<String>,
+    /// File size
+    pub file_size: Option<u64>,
+
+    /// Additional metadata
+    pub metadata: HashMap<String, serde_json::Value>,
+
+    /// Raw event data (if preserving original)
+    pub raw: Option<String>,
+}
+
+impl SiemEvent {
+    /// Create a new SIEM event
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use armature_siem::*;
+    ///
+    /// let event = SiemEvent::new("user.login")
+    ///     .category(EventCategory::Authentication)
+    ///     .severity(SiemSeverity::Low)
+    ///     .outcome(EventOutcome::Success)
+    ///     .src_ip("192.168.1.100")
+    ///     .src_user("alice")
+    ///     .action("login");
+    /// ```
+    pub fn new(event_type: impl Into<String>) -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            timestamp: Utc::now(),
+            event_type: event_type.into(),
+            category: EventCategory::default(),
+            severity: SiemSeverity::default(),
+            outcome: EventOutcome::default(),
+            action: "unknown".to_string(),
+            message: None,
+            src_ip: None,
+            src_port: None,
+            src_host: None,
+            src_user: None,
+            src_process: None,
+            dst_ip: None,
+            dst_port: None,
+            dst_host: None,
+            dst_user: None,
+            http_method: None,
+            url: None,
+            user_agent: None,
+            http_status: None,
+            bytes: None,
+            resource_type: None,
+            resource_id: None,
+            resource_name: None,
+            application: None,
+            service: None,
+            environment: None,
+            error_code: None,
+            error_message: None,
+            duration_ms: None,
+            protocol: None,
+            device_id: None,
+            device_type: None,
+            threat_indicator_type: None,
+            threat_indicator: None,
+            file_path: None,
+            file_hash: None,
+            file_size: None,
+            metadata: HashMap::new(),
+            raw: None,
+        }
+    }
+
+    /// Set event category
+    pub fn category(mut self, category: EventCategory) -> Self {
+        self.category = category;
+        self
+    }
+
+    /// Set severity
+    pub fn severity(mut self, severity: SiemSeverity) -> Self {
+        self.severity = severity;
+        self
+    }
+
+    /// Set outcome
+    pub fn outcome(mut self, outcome: EventOutcome) -> Self {
+        self.outcome = outcome;
+        self
+    }
+
+    /// Set action
+    pub fn action(mut self, action: impl Into<String>) -> Self {
+        self.action = action.into();
+        self
+    }
+
+    /// Set message
+    pub fn message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+
+    /// Set source IP
+    pub fn src_ip(mut self, ip: impl Into<String>) -> Self {
+        self.src_ip = Some(ip.into());
+        self
+    }
+
+    /// Set source port
+    pub fn src_port(mut self, port: u16) -> Self {
+        self.src_port = Some(port);
+        self
+    }
+
+    /// Set source hostname
+    pub fn src_host(mut self, host: impl Into<String>) -> Self {
+        self.src_host = Some(host.into());
+        self
+    }
+
+    /// Set source user
+    pub fn src_user(mut self, user: impl Into<String>) -> Self {
+        self.src_user = Some(user.into());
+        self
+    }
+
+    /// Set source process
+    pub fn src_process(mut self, process: impl Into<String>) -> Self {
+        self.src_process = Some(process.into());
+        self
+    }
+
+    /// Set destination IP
+    pub fn dst_ip(mut self, ip: impl Into<String>) -> Self {
+        self.dst_ip = Some(ip.into());
+        self
+    }
+
+    /// Set destination port
+    pub fn dst_port(mut self, port: u16) -> Self {
+        self.dst_port = Some(port);
+        self
+    }
+
+    /// Set destination hostname
+    pub fn dst_host(mut self, host: impl Into<String>) -> Self {
+        self.dst_host = Some(host.into());
+        self
+    }
+
+    /// Set destination user
+    pub fn dst_user(mut self, user: impl Into<String>) -> Self {
+        self.dst_user = Some(user.into());
+        self
+    }
+
+    /// Set HTTP method
+    pub fn http_method(mut self, method: impl Into<String>) -> Self {
+        self.http_method = Some(method.into());
+        self
+    }
+
+    /// Set URL
+    pub fn url(mut self, url: impl Into<String>) -> Self {
+        self.url = Some(url.into());
+        self
+    }
+
+    /// Set user agent
+    pub fn user_agent(mut self, ua: impl Into<String>) -> Self {
+        self.user_agent = Some(ua.into());
+        self
+    }
+
+    /// Set HTTP status
+    pub fn http_status(mut self, status: u16) -> Self {
+        self.http_status = Some(status);
+        self
+    }
+
+    /// Set bytes
+    pub fn bytes(mut self, bytes: u64) -> Self {
+        self.bytes = Some(bytes);
+        self
+    }
+
+    /// Set resource type
+    pub fn resource_type(mut self, rt: impl Into<String>) -> Self {
+        self.resource_type = Some(rt.into());
+        self
+    }
+
+    /// Set resource ID
+    pub fn resource_id(mut self, id: impl Into<String>) -> Self {
+        self.resource_id = Some(id.into());
+        self
+    }
+
+    /// Set resource name
+    pub fn resource_name(mut self, name: impl Into<String>) -> Self {
+        self.resource_name = Some(name.into());
+        self
+    }
+
+    /// Set application
+    pub fn application(mut self, app: impl Into<String>) -> Self {
+        self.application = Some(app.into());
+        self
+    }
+
+    /// Set service
+    pub fn service(mut self, service: impl Into<String>) -> Self {
+        self.service = Some(service.into());
+        self
+    }
+
+    /// Set environment
+    pub fn environment(mut self, env: impl Into<String>) -> Self {
+        self.environment = Some(env.into());
+        self
+    }
+
+    /// Set error code
+    pub fn error_code(mut self, code: impl Into<String>) -> Self {
+        self.error_code = Some(code.into());
+        self
+    }
+
+    /// Set error message
+    pub fn error_message(mut self, msg: impl Into<String>) -> Self {
+        self.error_message = Some(msg.into());
+        self
+    }
+
+    /// Set duration in milliseconds
+    pub fn duration_ms(mut self, ms: u64) -> Self {
+        self.duration_ms = Some(ms);
+        self
+    }
+
+    /// Set protocol
+    pub fn protocol(mut self, proto: impl Into<String>) -> Self {
+        self.protocol = Some(proto.into());
+        self
+    }
+
+    /// Set device ID
+    pub fn device_id(mut self, id: impl Into<String>) -> Self {
+        self.device_id = Some(id.into());
+        self
+    }
+
+    /// Set device type
+    pub fn device_type(mut self, dt: impl Into<String>) -> Self {
+        self.device_type = Some(dt.into());
+        self
+    }
+
+    /// Set threat indicator
+    pub fn threat_indicator(
+        mut self,
+        indicator_type: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Self {
+        self.threat_indicator_type = Some(indicator_type.into());
+        self.threat_indicator = Some(value.into());
+        self
+    }
+
+    /// Set file path
+    pub fn file_path(mut self, path: impl Into<String>) -> Self {
+        self.file_path = Some(path.into());
+        self
+    }
+
+    /// Set file hash
+    pub fn file_hash(mut self, hash: impl Into<String>) -> Self {
+        self.file_hash = Some(hash.into());
+        self
+    }
+
+    /// Set file size
+    pub fn file_size(mut self, size: u64) -> Self {
+        self.file_size = Some(size);
+        self
+    }
+
+    /// Add metadata
+    pub fn metadata(mut self, key: impl Into<String>, value: impl Into<serde_json::Value>) -> Self {
+        self.metadata.insert(key.into(), value.into());
+        self
+    }
+
+    /// Set raw event data
+    pub fn raw(mut self, raw: impl Into<String>) -> Self {
+        self.raw = Some(raw.into());
+        self
+    }
+
+    /// Set timestamp
+    pub fn with_timestamp(mut self, timestamp: DateTime<Utc>) -> Self {
+        self.timestamp = timestamp;
+        self
+    }
+
+    /// Set custom ID
+    pub fn with_id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+}
+
+#[cfg(feature = "audit")]
+impl From<armature_audit::AuditEvent> for SiemEvent {
+    fn from(audit: armature_audit::AuditEvent) -> Self {
+        let severity = match audit.severity {
+            armature_audit::AuditSeverity::Info => SiemSeverity::Low,
+            armature_audit::AuditSeverity::Warning => SiemSeverity::Medium,
+            armature_audit::AuditSeverity::Error => SiemSeverity::High,
+            armature_audit::AuditSeverity::Critical => SiemSeverity::Critical,
+        };
+
+        let outcome = match audit.status {
+            armature_audit::AuditStatus::Success => EventOutcome::Success,
+            armature_audit::AuditStatus::Failure
+            | armature_audit::AuditStatus::Denied
+            | armature_audit::AuditStatus::Error => EventOutcome::Failure,
+        };
+
+        let mut event = SiemEvent::new(&audit.event_type)
+            .with_id(&audit.id)
+            .with_timestamp(audit.timestamp)
+            .category(EventCategory::Web)
+            .severity(severity)
+            .outcome(outcome)
+            .action(&audit.action);
+
+        if let Some(user) = audit.user_id {
+            event = event.src_user(user);
+        }
+        if let Some(ip) = audit.ip_address {
+            event = event.src_ip(ip);
+        }
+        if let Some(ua) = audit.user_agent {
+            event = event.user_agent(ua);
+        }
+        if let Some(method) = audit.method {
+            event = event.http_method(method);
+        }
+        if let Some(path) = audit.path {
+            event = event.url(path);
+        }
+        if let Some(status) = audit.status_code {
+            event = event.http_status(status);
+        }
+        if let Some(rt) = audit.resource_type {
+            event = event.resource_type(rt);
+        }
+        if let Some(rid) = audit.resource_id {
+            event = event.resource_id(rid);
+        }
+        if let Some(err) = audit.error {
+            event = event.error_message(err);
+        }
+        if let Some(dur) = audit.duration_ms {
+            event = event.duration_ms(dur);
+        }
+
+        // Copy metadata
+        for (k, v) in audit.metadata {
+            event = event.metadata(k, v);
+        }
+
+        event
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_event_creation() {
+        let event = SiemEvent::new("user.login")
+            .category(EventCategory::Authentication)
+            .severity(SiemSeverity::Low)
+            .outcome(EventOutcome::Success)
+            .src_ip("192.168.1.100")
+            .src_user("alice")
+            .action("login");
+
+        assert_eq!(event.event_type, "user.login");
+        assert_eq!(event.category, EventCategory::Authentication);
+        assert_eq!(event.severity, SiemSeverity::Low);
+        assert_eq!(event.outcome, EventOutcome::Success);
+        assert_eq!(event.src_ip, Some("192.168.1.100".to_string()));
+        assert_eq!(event.src_user, Some("alice".to_string()));
+    }
+
+    #[test]
+    fn test_severity_conversion() {
+        assert_eq!(SiemSeverity::Unknown.as_cef_severity(), 0);
+        assert_eq!(SiemSeverity::Low.as_cef_severity(), 3);
+        assert_eq!(SiemSeverity::Medium.as_cef_severity(), 5);
+        assert_eq!(SiemSeverity::High.as_cef_severity(), 8);
+        assert_eq!(SiemSeverity::Critical.as_cef_severity(), 10);
+
+        assert_eq!(SiemSeverity::Critical.as_syslog_severity(), 2);
+    }
+
+    #[test]
+    fn test_event_metadata() {
+        let event = SiemEvent::new("test")
+            .metadata("custom_field", serde_json::json!("value"))
+            .metadata("count", serde_json::json!(42));
+
+        assert_eq!(
+            event.metadata.get("custom_field"),
+            Some(&serde_json::json!("value"))
+        );
+        assert_eq!(event.metadata.get("count"), Some(&serde_json::json!(42)));
+    }
+}

--- a/armature-siem/src/format/cef.rs
+++ b/armature-siem/src/format/cef.rs
@@ -1,0 +1,223 @@
+//! Common Event Format (CEF) formatter
+//!
+//! CEF is used by ArcSight, Splunk, and other enterprise SIEMs.
+//!
+//! Format: CEF:Version|Device Vendor|Device Product|Device Version|Signature ID|Name|Severity|Extension
+
+use super::EventFormatter;
+use crate::{SiemConfig, SiemEvent, SiemResult};
+
+/// CEF (Common Event Format) formatter
+///
+/// Formats events according to the CEF specification:
+/// `CEF:0|Vendor|Product|Version|SignatureID|Name|Severity|Extension`
+pub struct CefFormatter;
+
+impl CefFormatter {
+    /// Escape special characters in CEF header fields
+    fn escape_header(s: &str) -> String {
+        s.replace('\\', "\\\\")
+            .replace('|', "\\|")
+            .replace('\n', " ")
+            .replace('\r', " ")
+    }
+
+    /// Escape special characters in CEF extension values
+    fn escape_extension(s: &str) -> String {
+        s.replace('\\', "\\\\")
+            .replace('=', "\\=")
+            .replace('\n', "\\n")
+            .replace('\r', "\\r")
+    }
+
+    /// Build the CEF extension string
+    fn build_extension(event: &SiemEvent) -> String {
+        let mut ext = Vec::new();
+
+        // Standard CEF extension fields
+        ext.push(format!(
+            "rt={}",
+            event.timestamp.timestamp_millis()
+        ));
+
+        if let Some(ref ip) = event.src_ip {
+            ext.push(format!("src={}", Self::escape_extension(ip)));
+        }
+        if let Some(port) = event.src_port {
+            ext.push(format!("spt={}", port));
+        }
+        if let Some(ref host) = event.src_host {
+            ext.push(format!("shost={}", Self::escape_extension(host)));
+        }
+        if let Some(ref user) = event.src_user {
+            ext.push(format!("suser={}", Self::escape_extension(user)));
+        }
+        if let Some(ref process) = event.src_process {
+            ext.push(format!("sproc={}", Self::escape_extension(process)));
+        }
+
+        if let Some(ref ip) = event.dst_ip {
+            ext.push(format!("dst={}", Self::escape_extension(ip)));
+        }
+        if let Some(port) = event.dst_port {
+            ext.push(format!("dpt={}", port));
+        }
+        if let Some(ref host) = event.dst_host {
+            ext.push(format!("dhost={}", Self::escape_extension(host)));
+        }
+        if let Some(ref user) = event.dst_user {
+            ext.push(format!("duser={}", Self::escape_extension(user)));
+        }
+
+        if let Some(ref method) = event.http_method {
+            ext.push(format!("requestMethod={}", Self::escape_extension(method)));
+        }
+        if let Some(ref url) = event.url {
+            ext.push(format!("request={}", Self::escape_extension(url)));
+        }
+        if let Some(ref ua) = event.user_agent {
+            ext.push(format!(
+                "requestClientApplication={}",
+                Self::escape_extension(ua)
+            ));
+        }
+        if let Some(status) = event.http_status {
+            ext.push(format!("cn1={}", status));
+            ext.push("cn1Label=httpStatusCode".to_string());
+        }
+
+        if let Some(bytes) = event.bytes {
+            ext.push(format!("out={}", bytes));
+        }
+
+        if let Some(ref msg) = event.message {
+            ext.push(format!("msg={}", Self::escape_extension(msg)));
+        }
+
+        if let Some(ref proto) = event.protocol {
+            ext.push(format!("proto={}", Self::escape_extension(proto)));
+        }
+
+        if let Some(ref path) = event.file_path {
+            ext.push(format!("filePath={}", Self::escape_extension(path)));
+        }
+        if let Some(ref hash) = event.file_hash {
+            ext.push(format!("fileHash={}", Self::escape_extension(hash)));
+        }
+        if let Some(size) = event.file_size {
+            ext.push(format!("fsize={}", size));
+        }
+
+        if let Some(ref app) = event.application {
+            ext.push(format!("app={}", Self::escape_extension(app)));
+        }
+
+        if let Some(ref error) = event.error_message {
+            ext.push(format!("reason={}", Self::escape_extension(error)));
+        }
+
+        ext.push(format!("externalId={}", event.id));
+        ext.push(format!(
+            "outcome={}",
+            match event.outcome {
+                crate::EventOutcome::Success => "Success",
+                crate::EventOutcome::Failure => "Failure",
+                crate::EventOutcome::Unknown => "Unknown",
+            }
+        ));
+
+        ext.push(format!("cat={}", event.category));
+
+        // Add custom metadata
+        for (key, value) in &event.metadata {
+            let val_str = match value {
+                serde_json::Value::String(s) => s.clone(),
+                _ => value.to_string(),
+            };
+            ext.push(format!(
+                "cs1={} cs1Label={}",
+                Self::escape_extension(&val_str),
+                Self::escape_extension(key)
+            ));
+        }
+
+        ext.join(" ")
+    }
+}
+
+impl EventFormatter for CefFormatter {
+    fn format(&self, event: &SiemEvent, config: &SiemConfig) -> SiemResult<String> {
+        // CEF:Version|Device Vendor|Device Product|Device Version|Signature ID|Name|Severity|Extension
+        let cef = format!(
+            "CEF:0|{}|{}|{}|{}|{}|{}|{}",
+            Self::escape_header(&config.cef_vendor),
+            Self::escape_header(&config.cef_product),
+            Self::escape_header(&config.cef_version),
+            Self::escape_header(&event.event_type),
+            Self::escape_header(&event.action),
+            event.severity.as_cef_severity(),
+            Self::build_extension(event)
+        );
+
+        Ok(cef)
+    }
+
+    fn content_type(&self) -> &'static str {
+        "text/plain"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EventCategory, EventOutcome, SiemSeverity};
+
+    fn sample_event() -> SiemEvent {
+        SiemEvent::new("user.login")
+            .category(EventCategory::Authentication)
+            .severity(SiemSeverity::Low)
+            .outcome(EventOutcome::Success)
+            .src_ip("192.168.1.100")
+            .src_user("alice")
+            .action("login")
+            .message("User logged in successfully")
+    }
+
+    fn sample_config() -> SiemConfig {
+        SiemConfig {
+            cef_vendor: "Armature".to_string(),
+            cef_product: "WebApp".to_string(),
+            cef_version: "1.0".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_cef_format() {
+        let formatter = CefFormatter;
+        let event = sample_event();
+        let config = sample_config();
+
+        let result = formatter.format(&event, &config).unwrap();
+
+        assert!(result.starts_with("CEF:0|Armature|WebApp|1.0|"));
+        assert!(result.contains("login"));
+        assert!(result.contains("src=192.168.1.100"));
+        assert!(result.contains("suser=alice"));
+    }
+
+    #[test]
+    fn test_cef_escape_header() {
+        assert_eq!(CefFormatter::escape_header("test|pipe"), "test\\|pipe");
+        assert_eq!(CefFormatter::escape_header("test\\slash"), "test\\\\slash");
+    }
+
+    #[test]
+    fn test_cef_escape_extension() {
+        assert_eq!(CefFormatter::escape_extension("key=value"), "key\\=value");
+        assert_eq!(
+            CefFormatter::escape_extension("line1\nline2"),
+            "line1\\nline2"
+        );
+    }
+}

--- a/armature-siem/src/format/ecs.rs
+++ b/armature-siem/src/format/ecs.rs
@@ -1,0 +1,420 @@
+//! Elastic Common Schema (ECS) formatter
+//!
+//! Formats events according to Elastic Common Schema for use with
+//! Elasticsearch, Elastic Security, and Elastic SIEM.
+
+use super::EventFormatter;
+use crate::{SiemConfig, SiemEvent, SiemResult};
+use serde::Serialize;
+use std::collections::HashMap;
+
+/// ECS (Elastic Common Schema) formatter
+pub struct EcsFormatter;
+
+/// ECS formatted event structure
+#[derive(Serialize)]
+struct EcsEvent<'a> {
+    #[serde(rename = "@timestamp")]
+    timestamp: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<&'a str>,
+
+    event: EcsEventField<'a>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source: Option<EcsSource<'a>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    destination: Option<EcsDestination<'a>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user: Option<EcsUser<'a>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    http: Option<EcsHttp<'a>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    url: Option<EcsUrl<'a>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user_agent: Option<EcsUserAgent<'a>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    file: Option<EcsFile<'a>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<EcsError<'a>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    process: Option<EcsProcess<'a>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    host: Option<EcsHost>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    service: Option<EcsService<'a>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    network: Option<EcsNetwork<'a>>,
+
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    labels: HashMap<String, serde_json::Value>,
+
+    ecs: EcsVersion,
+}
+
+#[derive(Serialize)]
+struct EcsEventField<'a> {
+    id: &'a str,
+    kind: &'static str,
+    category: Vec<String>,
+    #[serde(rename = "type")]
+    event_type: Vec<&'a str>,
+    action: &'a str,
+    outcome: &'static str,
+    severity: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    duration: Option<u64>,
+    original: &'a str,
+}
+
+#[derive(Serialize)]
+struct EcsSource<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ip: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    domain: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct EcsDestination<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ip: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    domain: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct EcsUser<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct EcsHttp<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    request: Option<EcsHttpRequest<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    response: Option<EcsHttpResponse>,
+}
+
+#[derive(Serialize)]
+struct EcsHttpRequest<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    method: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bytes: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct EcsHttpResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status_code: Option<u16>,
+}
+
+#[derive(Serialize)]
+struct EcsUrl<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    original: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct EcsUserAgent<'a> {
+    original: &'a str,
+}
+
+#[derive(Serialize)]
+struct EcsFile<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hash: Option<EcsFileHash<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    size: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct EcsFileHash<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sha256: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct EcsError<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    code: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct EcsProcess<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct EcsHost {
+    name: String,
+}
+
+#[derive(Serialize)]
+struct EcsService<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    environment: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct EcsNetwork<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    protocol: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bytes: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct EcsVersion {
+    version: &'static str,
+}
+
+impl EcsFormatter {
+    fn get_hostname() -> String {
+        hostname::get()
+            .map(|h| h.to_string_lossy().to_string())
+            .unwrap_or_else(|_| "unknown".to_string())
+    }
+
+    fn map_outcome(outcome: crate::EventOutcome) -> &'static str {
+        match outcome {
+            crate::EventOutcome::Success => "success",
+            crate::EventOutcome::Failure => "failure",
+            crate::EventOutcome::Unknown => "unknown",
+        }
+    }
+}
+
+impl EventFormatter for EcsFormatter {
+    fn format(&self, event: &SiemEvent, _config: &SiemConfig) -> SiemResult<String> {
+        // Build source if any source fields are present
+        let source = if event.src_ip.is_some() || event.src_port.is_some() || event.src_host.is_some() {
+            Some(EcsSource {
+                ip: event.src_ip.as_deref(),
+                port: event.src_port,
+                domain: event.src_host.as_deref(),
+            })
+        } else {
+            None
+        };
+
+        // Build destination if any dest fields are present
+        let destination = if event.dst_ip.is_some() || event.dst_port.is_some() || event.dst_host.is_some() {
+            Some(EcsDestination {
+                ip: event.dst_ip.as_deref(),
+                port: event.dst_port,
+                domain: event.dst_host.as_deref(),
+            })
+        } else {
+            None
+        };
+
+        // Build user
+        let user = if event.src_user.is_some() {
+            Some(EcsUser {
+                name: event.src_user.as_deref(),
+                id: None,
+            })
+        } else {
+            None
+        };
+
+        // Build HTTP
+        let http = if event.http_method.is_some() || event.http_status.is_some() {
+            Some(EcsHttp {
+                request: if event.http_method.is_some() || event.bytes.is_some() {
+                    Some(EcsHttpRequest {
+                        method: event.http_method.as_deref(),
+                        bytes: event.bytes,
+                    })
+                } else {
+                    None
+                },
+                response: if event.http_status.is_some() {
+                    Some(EcsHttpResponse {
+                        status_code: event.http_status,
+                    })
+                } else {
+                    None
+                },
+            })
+        } else {
+            None
+        };
+
+        // Build URL
+        let url = event.url.as_ref().map(|u| EcsUrl {
+            original: Some(u.as_str()),
+            path: Some(u.as_str()),
+        });
+
+        // Build user agent
+        let user_agent = event.user_agent.as_ref().map(|ua| EcsUserAgent {
+            original: ua.as_str(),
+        });
+
+        // Build file
+        let file = if event.file_path.is_some() || event.file_hash.is_some() || event.file_size.is_some() {
+            Some(EcsFile {
+                path: event.file_path.as_deref(),
+                hash: event.file_hash.as_ref().map(|h| EcsFileHash {
+                    sha256: Some(h.as_str()),
+                }),
+                size: event.file_size,
+            })
+        } else {
+            None
+        };
+
+        // Build error
+        let error = if event.error_code.is_some() || event.error_message.is_some() {
+            Some(EcsError {
+                code: event.error_code.as_deref(),
+                message: event.error_message.as_deref(),
+            })
+        } else {
+            None
+        };
+
+        // Build process
+        let process = event.src_process.as_ref().map(|p| EcsProcess {
+            name: Some(p.as_str()),
+        });
+
+        // Build service
+        let service = if event.service.is_some() || event.environment.is_some() {
+            Some(EcsService {
+                name: event.service.as_deref(),
+                environment: event.environment.as_deref(),
+            })
+        } else {
+            None
+        };
+
+        // Build network
+        let network = if event.protocol.is_some() || event.bytes.is_some() {
+            Some(EcsNetwork {
+                protocol: event.protocol.as_deref(),
+                bytes: event.bytes,
+            })
+        } else {
+            None
+        };
+
+        let ecs_event = EcsEvent {
+            timestamp: event.timestamp.to_rfc3339(),
+            message: event.message.as_deref(),
+            event: EcsEventField {
+                id: &event.id,
+                kind: "event",
+                category: vec![event.category.to_string()],
+                event_type: vec![&event.event_type],
+                action: &event.action,
+                outcome: Self::map_outcome(event.outcome),
+                severity: event.severity.as_cef_severity(),
+                duration: event.duration_ms.map(|d| d * 1_000_000), // Convert to nanoseconds
+                original: &event.event_type,
+            },
+            source,
+            destination,
+            user,
+            http,
+            url,
+            user_agent,
+            file,
+            error,
+            process,
+            host: Some(EcsHost {
+                name: Self::get_hostname(),
+            }),
+            service,
+            network,
+            labels: event.metadata.clone(),
+            ecs: EcsVersion { version: "8.11" },
+        };
+
+        Ok(serde_json::to_string(&ecs_event)?)
+    }
+
+    fn content_type(&self) -> &'static str {
+        "application/json"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EventCategory, EventOutcome, SiemSeverity};
+
+    fn sample_event() -> SiemEvent {
+        SiemEvent::new("user.authentication")
+            .category(EventCategory::Authentication)
+            .severity(SiemSeverity::Low)
+            .outcome(EventOutcome::Success)
+            .src_ip("192.168.1.100")
+            .src_user("alice")
+            .action("login")
+            .message("User logged in successfully")
+            .http_method("POST")
+            .http_status(200)
+            .url("/api/auth/login")
+    }
+
+    fn sample_config() -> SiemConfig {
+        SiemConfig::default()
+    }
+
+    #[test]
+    fn test_ecs_format() {
+        let formatter = EcsFormatter;
+        let event = sample_event();
+        let config = sample_config();
+
+        let result = formatter.format(&event, &config).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        assert!(parsed.get("@timestamp").is_some());
+        assert_eq!(parsed["event"]["action"], "login");
+        assert_eq!(parsed["event"]["outcome"], "success");
+        assert_eq!(parsed["source"]["ip"], "192.168.1.100");
+        assert_eq!(parsed["user"]["name"], "alice");
+        assert_eq!(parsed["http"]["request"]["method"], "POST");
+        assert_eq!(parsed["http"]["response"]["status_code"], 200);
+        assert_eq!(parsed["ecs"]["version"], "8.11");
+    }
+
+    #[test]
+    fn test_ecs_content_type() {
+        let formatter = EcsFormatter;
+        assert_eq!(formatter.content_type(), "application/json");
+    }
+}

--- a/armature-siem/src/format/json.rs
+++ b/armature-siem/src/format/json.rs
@@ -1,0 +1,139 @@
+//! JSON formatter for SIEM events
+//!
+//! Simple JSON serialization for events, compatible with most SIEM systems.
+
+use super::EventFormatter;
+use crate::{SiemConfig, SiemEvent, SiemResult};
+use serde::Serialize;
+
+/// JSON formatter
+pub struct JsonFormatter;
+
+/// Splunk HEC event wrapper
+#[derive(Serialize)]
+struct SplunkHecEvent<'a> {
+    time: i64,
+    host: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sourcetype: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    index: Option<&'a str>,
+    event: &'a SiemEvent,
+}
+
+impl JsonFormatter {
+    /// Get hostname
+    fn get_hostname() -> String {
+        hostname::get()
+            .map(|h| h.to_string_lossy().to_string())
+            .unwrap_or_else(|_| "unknown".to_string())
+    }
+}
+
+impl EventFormatter for JsonFormatter {
+    fn format(&self, event: &SiemEvent, config: &SiemConfig) -> SiemResult<String> {
+        // For Splunk HEC, wrap in HEC format
+        if config.provider == crate::SiemProvider::Splunk {
+            let hec_event = SplunkHecEvent {
+                time: event.timestamp.timestamp(),
+                host: Self::get_hostname(),
+                source: config.source.as_deref(),
+                sourcetype: config.source_type.as_deref(),
+                index: config.index.as_deref(),
+                event,
+            };
+            Ok(serde_json::to_string(&hec_event)?)
+        } else {
+            // Generic JSON output
+            Ok(serde_json::to_string(event)?)
+        }
+    }
+
+    fn format_batch(&self, events: &[SiemEvent], config: &SiemConfig) -> SiemResult<String> {
+        if config.provider == crate::SiemProvider::Splunk {
+            // Splunk HEC accepts newline-delimited JSON
+            let formatted: SiemResult<Vec<String>> = events
+                .iter()
+                .map(|e| self.format(e, config))
+                .collect();
+            Ok(formatted?.join("\n"))
+        } else {
+            // Generic: JSON array
+            Ok(serde_json::to_string(events)?)
+        }
+    }
+
+    fn content_type(&self) -> &'static str {
+        "application/json"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EventCategory, EventOutcome, SiemProvider, SiemSeverity};
+
+    fn sample_event() -> SiemEvent {
+        SiemEvent::new("user.login")
+            .category(EventCategory::Authentication)
+            .severity(SiemSeverity::Low)
+            .outcome(EventOutcome::Success)
+            .src_ip("192.168.1.100")
+            .src_user("alice")
+            .action("login")
+    }
+
+    #[test]
+    fn test_json_format_generic() {
+        let formatter = JsonFormatter;
+        let event = sample_event();
+        let config = SiemConfig {
+            provider: SiemProvider::Custom,
+            ..Default::default()
+        };
+
+        let result = formatter.format(&event, &config).unwrap();
+
+        assert!(result.contains("\"event_type\":\"user.login\""));
+        assert!(result.contains("\"src_ip\":\"192.168.1.100\""));
+    }
+
+    #[test]
+    fn test_json_format_splunk() {
+        let formatter = JsonFormatter;
+        let event = sample_event();
+        let config = SiemConfig {
+            provider: SiemProvider::Splunk,
+            source: Some("armature".to_string()),
+            source_type: Some("security".to_string()),
+            index: Some("main".to_string()),
+            ..Default::default()
+        };
+
+        let result = formatter.format(&event, &config).unwrap();
+
+        assert!(result.contains("\"time\":"));
+        assert!(result.contains("\"host\":"));
+        assert!(result.contains("\"source\":\"armature\""));
+        assert!(result.contains("\"sourcetype\":\"security\""));
+        assert!(result.contains("\"event\":"));
+    }
+
+    #[test]
+    fn test_batch_format() {
+        let formatter = JsonFormatter;
+        let events = vec![sample_event(), sample_event()];
+        let config = SiemConfig {
+            provider: SiemProvider::Splunk,
+            ..Default::default()
+        };
+
+        let result = formatter.format_batch(&events, &config).unwrap();
+
+        // Should be newline-delimited for Splunk
+        let lines: Vec<&str> = result.lines().collect();
+        assert_eq!(lines.len(), 2);
+    }
+}

--- a/armature-siem/src/format/leef.rs
+++ b/armature-siem/src/format/leef.rs
@@ -1,0 +1,234 @@
+//! Log Event Extended Format (LEEF) formatter
+//!
+//! LEEF is used by IBM QRadar and other IBM security products.
+//!
+//! Format: LEEF:Version|Vendor|Product|Version|EventID|<tab-delimited attributes>
+
+use super::EventFormatter;
+use crate::{SiemConfig, SiemEvent, SiemResult};
+
+/// LEEF (Log Event Extended Format) formatter
+///
+/// Formats events according to the LEEF 2.0 specification:
+/// `LEEF:2.0|Vendor|Product|Version|EventID|<attributes>`
+pub struct LeefFormatter;
+
+impl LeefFormatter {
+    /// Escape special characters in LEEF header fields
+    fn escape_header(s: &str) -> String {
+        s.replace('|', "\\|")
+            .replace('\n', " ")
+            .replace('\r', " ")
+    }
+
+    /// Escape special characters in LEEF attribute values
+    fn escape_value(s: &str) -> String {
+        s.replace('\t', " ")
+            .replace('\n', "\\n")
+            .replace('\r', "\\r")
+            .replace('=', "\\=")
+    }
+
+    /// Build the LEEF attributes string (tab-delimited key=value pairs)
+    fn build_attributes(event: &SiemEvent) -> String {
+        let mut attrs = Vec::new();
+
+        // Time stamp
+        attrs.push(format!("devTime={}", event.timestamp.to_rfc3339()));
+
+        // Severity mapping for QRadar
+        attrs.push(format!("sev={}", event.severity.as_cef_severity()));
+
+        // Category
+        attrs.push(format!("cat={}", event.category));
+
+        // Source fields
+        if let Some(ref ip) = event.src_ip {
+            attrs.push(format!("src={}", Self::escape_value(ip)));
+        }
+        if let Some(port) = event.src_port {
+            attrs.push(format!("srcPort={}", port));
+        }
+        if let Some(ref host) = event.src_host {
+            attrs.push(format!("srcHostName={}", Self::escape_value(host)));
+        }
+        if let Some(ref user) = event.src_user {
+            attrs.push(format!("usrName={}", Self::escape_value(user)));
+        }
+
+        // Destination fields
+        if let Some(ref ip) = event.dst_ip {
+            attrs.push(format!("dst={}", Self::escape_value(ip)));
+        }
+        if let Some(port) = event.dst_port {
+            attrs.push(format!("dstPort={}", port));
+        }
+        if let Some(ref host) = event.dst_host {
+            attrs.push(format!("dstHostName={}", Self::escape_value(host)));
+        }
+
+        // HTTP fields
+        if let Some(ref method) = event.http_method {
+            attrs.push(format!("httpMethod={}", Self::escape_value(method)));
+        }
+        if let Some(ref url) = event.url {
+            attrs.push(format!("url={}", Self::escape_value(url)));
+        }
+        if let Some(ref ua) = event.user_agent {
+            attrs.push(format!("userAgent={}", Self::escape_value(ua)));
+        }
+        if let Some(status) = event.http_status {
+            attrs.push(format!("httpStatusCode={}", status));
+        }
+
+        // Protocol
+        if let Some(ref proto) = event.protocol {
+            attrs.push(format!("proto={}", Self::escape_value(proto)));
+        }
+
+        // Bytes
+        if let Some(bytes) = event.bytes {
+            attrs.push(format!("bytesOut={}", bytes));
+        }
+
+        // Action and outcome
+        attrs.push(format!("action={}", Self::escape_value(&event.action)));
+        attrs.push(format!(
+            "outcome={}",
+            match event.outcome {
+                crate::EventOutcome::Success => "success",
+                crate::EventOutcome::Failure => "failure",
+                crate::EventOutcome::Unknown => "unknown",
+            }
+        ));
+
+        // Message
+        if let Some(ref msg) = event.message {
+            attrs.push(format!("msg={}", Self::escape_value(msg)));
+        }
+
+        // Resource fields
+        if let Some(ref rt) = event.resource_type {
+            attrs.push(format!("resourceType={}", Self::escape_value(rt)));
+        }
+        if let Some(ref rid) = event.resource_id {
+            attrs.push(format!("resourceId={}", Self::escape_value(rid)));
+        }
+
+        // Application context
+        if let Some(ref app) = event.application {
+            attrs.push(format!("application={}", Self::escape_value(app)));
+        }
+        if let Some(ref svc) = event.service {
+            attrs.push(format!("service={}", Self::escape_value(svc)));
+        }
+
+        // File information
+        if let Some(ref path) = event.file_path {
+            attrs.push(format!("fileName={}", Self::escape_value(path)));
+        }
+        if let Some(ref hash) = event.file_hash {
+            attrs.push(format!("fileHash={}", Self::escape_value(hash)));
+        }
+        if let Some(size) = event.file_size {
+            attrs.push(format!("fileSize={}", size));
+        }
+
+        // Error information
+        if let Some(ref err) = event.error_message {
+            attrs.push(format!("errorMsg={}", Self::escape_value(err)));
+        }
+        if let Some(ref code) = event.error_code {
+            attrs.push(format!("errorCode={}", Self::escape_value(code)));
+        }
+
+        // Duration
+        if let Some(dur) = event.duration_ms {
+            attrs.push(format!("duration={}", dur));
+        }
+
+        // External ID
+        attrs.push(format!("externalId={}", event.id));
+
+        // Custom metadata
+        for (key, value) in &event.metadata {
+            let val_str = match value {
+                serde_json::Value::String(s) => s.clone(),
+                _ => value.to_string(),
+            };
+            attrs.push(format!(
+                "{}={}",
+                Self::escape_value(key),
+                Self::escape_value(&val_str)
+            ));
+        }
+
+        attrs.join("\t")
+    }
+}
+
+impl EventFormatter for LeefFormatter {
+    fn format(&self, event: &SiemEvent, config: &SiemConfig) -> SiemResult<String> {
+        // LEEF:Version|Vendor|Product|Version|EventID|attributes
+        let leef = format!(
+            "LEEF:2.0|{}|{}|{}|{}|{}",
+            Self::escape_header(&config.cef_vendor),
+            Self::escape_header(&config.cef_product),
+            Self::escape_header(&config.cef_version),
+            Self::escape_header(&event.event_type),
+            Self::build_attributes(event)
+        );
+
+        Ok(leef)
+    }
+
+    fn content_type(&self) -> &'static str {
+        "text/plain"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EventCategory, EventOutcome, SiemSeverity};
+
+    fn sample_event() -> SiemEvent {
+        SiemEvent::new("user.login")
+            .category(EventCategory::Authentication)
+            .severity(SiemSeverity::High)
+            .outcome(EventOutcome::Failure)
+            .src_ip("10.0.0.50")
+            .src_user("bob")
+            .action("login_attempt")
+            .message("Failed login attempt")
+    }
+
+    fn sample_config() -> SiemConfig {
+        SiemConfig {
+            cef_vendor: "Armature".to_string(),
+            cef_product: "Security".to_string(),
+            cef_version: "2.0".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_leef_format() {
+        let formatter = LeefFormatter;
+        let event = sample_event();
+        let config = sample_config();
+
+        let result = formatter.format(&event, &config).unwrap();
+
+        assert!(result.starts_with("LEEF:2.0|Armature|Security|2.0|user.login|"));
+        assert!(result.contains("src=10.0.0.50"));
+        assert!(result.contains("usrName=bob"));
+        assert!(result.contains("outcome=failure"));
+    }
+
+    #[test]
+    fn test_leef_escape() {
+        assert_eq!(LeefFormatter::escape_header("test|pipe"), "test\\|pipe");
+        assert_eq!(LeefFormatter::escape_value("key=value"), "key\\=value");
+    }
+}

--- a/armature-siem/src/format/mod.rs
+++ b/armature-siem/src/format/mod.rs
@@ -1,0 +1,100 @@
+//! SIEM event format converters
+//!
+//! This module provides formatters for various SIEM event formats:
+//!
+//! - **CEF** - Common Event Format (ArcSight, Splunk, etc.)
+//! - **LEEF** - Log Event Extended Format (IBM QRadar)
+//! - **Syslog** - RFC 5424 Syslog format
+//! - **JSON** - Generic JSON format
+//! - **ECS** - Elastic Common Schema
+
+mod cef;
+mod ecs;
+mod json;
+mod leef;
+mod syslog;
+
+pub use cef::*;
+pub use ecs::*;
+pub use json::*;
+pub use leef::*;
+pub use syslog::*;
+
+use crate::{EventFormat, SiemConfig, SiemEvent, SiemResult};
+
+/// Trait for formatting SIEM events
+pub trait EventFormatter: Send + Sync {
+    /// Format an event to string
+    fn format(&self, event: &SiemEvent, config: &SiemConfig) -> SiemResult<String>;
+
+    /// Format multiple events (for batch sending)
+    fn format_batch(&self, events: &[SiemEvent], config: &SiemConfig) -> SiemResult<String> {
+        let formatted: SiemResult<Vec<String>> = events
+            .iter()
+            .map(|e| self.format(e, config))
+            .collect();
+        Ok(formatted?.join("\n"))
+    }
+
+    /// Get the content type for HTTP transport
+    fn content_type(&self) -> &'static str;
+}
+
+/// Get a formatter for the specified format
+pub fn get_formatter(format: EventFormat) -> Box<dyn EventFormatter> {
+    match format {
+        EventFormat::Json => Box::new(JsonFormatter),
+        EventFormat::Cef => Box::new(CefFormatter),
+        EventFormat::Leef => Box::new(LeefFormatter),
+        EventFormat::Syslog => Box::new(SyslogFormatter),
+        EventFormat::Ecs => Box::new(EcsFormatter),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EventCategory, EventOutcome, SiemSeverity};
+
+    fn sample_event() -> SiemEvent {
+        SiemEvent::new("user.login")
+            .category(EventCategory::Authentication)
+            .severity(SiemSeverity::Low)
+            .outcome(EventOutcome::Success)
+            .src_ip("192.168.1.100")
+            .src_user("alice")
+            .action("login")
+            .message("User logged in successfully")
+    }
+
+    fn sample_config() -> SiemConfig {
+        SiemConfig {
+            app_name: "test-app".to_string(),
+            cef_vendor: "TestVendor".to_string(),
+            cef_product: "TestProduct".to_string(),
+            cef_version: "1.0".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_get_formatter() {
+        let json_formatter = get_formatter(EventFormat::Json);
+        assert_eq!(json_formatter.content_type(), "application/json");
+
+        let cef_formatter = get_formatter(EventFormat::Cef);
+        assert_eq!(cef_formatter.content_type(), "text/plain");
+    }
+
+    #[test]
+    fn test_batch_formatting() {
+        let events = vec![sample_event(), sample_event()];
+        let config = sample_config();
+        let formatter = get_formatter(EventFormat::Json);
+
+        let result = formatter.format_batch(&events, &config);
+        assert!(result.is_ok());
+        let formatted = result.unwrap();
+        assert!(formatted.contains('\n'));
+    }
+}

--- a/armature-siem/src/format/syslog.rs
+++ b/armature-siem/src/format/syslog.rs
@@ -1,0 +1,209 @@
+//! Syslog RFC 5424 formatter
+//!
+//! Formats events according to RFC 5424 (The Syslog Protocol)
+
+use super::EventFormatter;
+use crate::{SiemConfig, SiemEvent, SiemResult, SyslogFacility};
+
+/// Syslog RFC 5424 formatter
+pub struct SyslogFormatter;
+
+impl SyslogFormatter {
+    /// Calculate the PRI value (facility * 8 + severity)
+    fn calculate_pri(facility: SyslogFacility, severity: u8) -> u8 {
+        (facility as u8) * 8 + severity
+    }
+
+    /// Get hostname
+    fn get_hostname() -> String {
+        hostname::get()
+            .map(|h| h.to_string_lossy().to_string())
+            .unwrap_or_else(|_| "-".to_string())
+    }
+
+    /// Escape structured data parameter value
+    fn escape_sd_value(s: &str) -> String {
+        s.replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace(']', "\\]")
+    }
+
+    /// Build structured data section
+    fn build_structured_data(event: &SiemEvent, _config: &SiemConfig) -> String {
+        let mut sd_parts = Vec::new();
+
+        // armature@32473 - using a private enterprise number style ID
+        let mut armature_sd = vec![
+            format!("eventId=\"{}\"", Self::escape_sd_value(&event.id)),
+            format!("eventType=\"{}\"", Self::escape_sd_value(&event.event_type)),
+            format!("category=\"{}\"", event.category),
+            format!(
+                "outcome=\"{}\"",
+                match event.outcome {
+                    crate::EventOutcome::Success => "success",
+                    crate::EventOutcome::Failure => "failure",
+                    crate::EventOutcome::Unknown => "unknown",
+                }
+            ),
+        ];
+
+        if let Some(ref ip) = event.src_ip {
+            armature_sd.push(format!("srcIp=\"{}\"", Self::escape_sd_value(ip)));
+        }
+        if let Some(ref user) = event.src_user {
+            armature_sd.push(format!("srcUser=\"{}\"", Self::escape_sd_value(user)));
+        }
+        if let Some(ref ip) = event.dst_ip {
+            armature_sd.push(format!("dstIp=\"{}\"", Self::escape_sd_value(ip)));
+        }
+        if let Some(ref method) = event.http_method {
+            armature_sd.push(format!("httpMethod=\"{}\"", Self::escape_sd_value(method)));
+        }
+        if let Some(ref url) = event.url {
+            armature_sd.push(format!("url=\"{}\"", Self::escape_sd_value(url)));
+        }
+        if let Some(status) = event.http_status {
+            armature_sd.push(format!("httpStatus=\"{}\"", status));
+        }
+        if let Some(ref app) = event.application {
+            armature_sd.push(format!("application=\"{}\"", Self::escape_sd_value(app)));
+        }
+        if let Some(dur) = event.duration_ms {
+            armature_sd.push(format!("durationMs=\"{}\"", dur));
+        }
+
+        sd_parts.push(format!(
+            "[armature@32473 {}]",
+            armature_sd.join(" ")
+        ));
+
+        // Add custom metadata as additional structured data
+        if !event.metadata.is_empty() {
+            let meta_params: Vec<String> = event
+                .metadata
+                .iter()
+                .map(|(k, v)| {
+                    let val_str = match v {
+                        serde_json::Value::String(s) => s.clone(),
+                        _ => v.to_string(),
+                    };
+                    format!("{}=\"{}\"", k, Self::escape_sd_value(&val_str))
+                })
+                .collect();
+
+            if !meta_params.is_empty() {
+                sd_parts.push(format!(
+                    "[meta@32473 {}]",
+                    meta_params.join(" ")
+                ));
+            }
+        }
+
+        if sd_parts.is_empty() {
+            "-".to_string()
+        } else {
+            sd_parts.join("")
+        }
+    }
+}
+
+impl EventFormatter for SyslogFormatter {
+    fn format(&self, event: &SiemEvent, config: &SiemConfig) -> SiemResult<String> {
+        // RFC 5424 format:
+        // <PRI>VERSION TIMESTAMP HOSTNAME APP-NAME PROCID MSGID STRUCTURED-DATA MSG
+
+        let pri = Self::calculate_pri(
+            config.syslog_facility,
+            event.severity.as_syslog_severity(),
+        );
+        let version = 1;
+        let timestamp = event.timestamp.to_rfc3339();
+        let hostname = Self::get_hostname();
+        let app_name = &config.app_name;
+        let proc_id = std::process::id();
+        let msg_id = &event.event_type;
+        let structured_data = Self::build_structured_data(event, config);
+
+        // Build message
+        let msg = event
+            .message
+            .as_ref()
+            .map(|m| format!(" {}", m))
+            .unwrap_or_default();
+
+        let syslog = format!(
+            "<{}>{} {} {} {} {} {} {}{}",
+            pri, version, timestamp, hostname, app_name, proc_id, msg_id, structured_data, msg
+        );
+
+        Ok(syslog)
+    }
+
+    fn content_type(&self) -> &'static str {
+        "text/plain"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EventCategory, EventOutcome, SiemSeverity};
+
+    fn sample_event() -> SiemEvent {
+        SiemEvent::new("auth.failure")
+            .category(EventCategory::Authentication)
+            .severity(SiemSeverity::High)
+            .outcome(EventOutcome::Failure)
+            .src_ip("192.168.1.100")
+            .src_user("attacker")
+            .action("login")
+            .message("Authentication failed: invalid password")
+    }
+
+    fn sample_config() -> SiemConfig {
+        SiemConfig {
+            app_name: "myapp".to_string(),
+            syslog_facility: SyslogFacility::Auth,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_syslog_format() {
+        let formatter = SyslogFormatter;
+        let event = sample_event();
+        let config = sample_config();
+
+        let result = formatter.format(&event, &config).unwrap();
+
+        // Auth facility (4) * 8 + severity 3 (error) = 35
+        assert!(result.starts_with("<35>1 "));
+        assert!(result.contains("myapp"));
+        assert!(result.contains("auth.failure"));
+        assert!(result.contains("[armature@32473"));
+        assert!(result.contains("Authentication failed"));
+    }
+
+    #[test]
+    fn test_pri_calculation() {
+        // User facility (1) * 8 + info severity (6) = 14
+        assert_eq!(SyslogFormatter::calculate_pri(SyslogFacility::User, 6), 14);
+        // Local0 facility (16) * 8 + critical (2) = 130
+        assert_eq!(
+            SyslogFormatter::calculate_pri(SyslogFacility::Local0, 2),
+            130
+        );
+    }
+
+    #[test]
+    fn test_sd_escape() {
+        assert_eq!(
+            SyslogFormatter::escape_sd_value("test\"quote"),
+            "test\\\"quote"
+        );
+        assert_eq!(
+            SyslogFormatter::escape_sd_value("test]bracket"),
+            "test\\]bracket"
+        );
+    }
+}

--- a/armature-siem/src/lib.rs
+++ b/armature-siem/src/lib.rs
@@ -1,0 +1,212 @@
+//! Enterprise SIEM integration for Armature
+//!
+//! This crate provides integration with enterprise Security Information and Event
+//! Management (SIEM) systems including Splunk, Elasticsearch, IBM QRadar,
+//! Microsoft Sentinel, Datadog, ArcSight, and more.
+//!
+//! # Features
+//!
+//! - **Multiple SIEM Providers** - Splunk, Elastic, QRadar, Sentinel, Datadog, ArcSight
+//! - **Multiple Formats** - JSON, CEF, LEEF, Syslog RFC 5424, Elastic Common Schema
+//! - **Multiple Transports** - HTTPS, TCP, UDP, TLS
+//! - **Batching** - Automatic event batching for efficiency
+//! - **Retry Logic** - Built-in retry with exponential backoff
+//! - **Audit Integration** - Convert armature-audit events to SIEM events
+//!
+//! # Quick Start
+//!
+//! ## Splunk HEC
+//!
+//! ```no_run
+//! use armature_siem::*;
+//!
+//! # async fn example() -> Result<(), SiemError> {
+//! let config = SplunkConfig::hec("https://splunk.example.com:8088")
+//!     .token("your-hec-token")
+//!     .index("security")
+//!     .build()?;
+//!
+//! let client = SiemClient::new(config)?;
+//!
+//! client.send(SiemEvent::new("user.login")
+//!     .category(EventCategory::Authentication)
+//!     .severity(SiemSeverity::Low)
+//!     .outcome(EventOutcome::Success)
+//!     .src_user("alice")
+//!     .src_ip("192.168.1.100")
+//!     .action("login")).await?;
+//!
+//! client.close().await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Elasticsearch with ECS
+//!
+//! ```no_run
+//! use armature_siem::*;
+//!
+//! # async fn example() -> Result<(), SiemError> {
+//! let config = ElasticConfig::new("https://elastic.example.com:9200")
+//!     .index("security-events")
+//!     .basic_auth("elastic", "password")
+//!     .build()?;
+//!
+//! let client = SiemClient::new(config)?;
+//!
+//! client.send(SiemEvent::new("file.access")
+//!     .category(EventCategory::File)
+//!     .severity(SiemSeverity::Medium)
+//!     .file_path("/etc/passwd")
+//!     .src_user("root")
+//!     .action("read")).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## IBM QRadar with LEEF
+//!
+//! ```no_run
+//! use armature_siem::*;
+//!
+//! # async fn example() -> Result<(), SiemError> {
+//! let config = QRadarConfig::leef("qradar.example.com:514")
+//!     .cef_vendor("MyCompany")
+//!     .cef_product("MyApp")
+//!     .build()?;
+//!
+//! let client = SiemClient::new(config)?;
+//!
+//! client.send(SiemEvent::new("auth.failure")
+//!     .category(EventCategory::Authentication)
+//!     .severity(SiemSeverity::High)
+//!     .outcome(EventOutcome::Failure)
+//!     .src_ip("10.0.0.50")
+//!     .action("login_attempt")
+//!     .message("Brute force attempt detected")).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Generic Syslog
+//!
+//! ```no_run
+//! use armature_siem::*;
+//!
+//! # async fn example() -> Result<(), SiemError> {
+//! let config = SyslogConfig::udp("syslog.example.com:514")
+//!     .app_name("myapp")
+//!     .syslog_facility(SyslogFacility::Auth)
+//!     .build()?;
+//!
+//! let client = SiemClient::new(config)?;
+//!
+//! client.send(SiemEvent::new("session.created")
+//!     .category(EventCategory::Session)
+//!     .src_user("bob")
+//!     .action("create")).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Event Categories
+//!
+//! Events are categorized using standard security event categories:
+//!
+//! - `Authentication` - Login, logout, password changes
+//! - `Authorization` - Permission checks, access control
+//! - `File` - File access, modification, deletion
+//! - `Network` - Network connections, traffic
+//! - `Process` - Process creation, termination
+//! - `Session` - Session management
+//! - `Threat` - Threat detection, malware
+//! - `Web` - HTTP requests, API calls
+//!
+//! # Severity Levels
+//!
+//! Severity levels map to standard SIEM severity scales:
+//!
+//! | Level | CEF (0-10) | Syslog (0-7) |
+//! |-------|------------|--------------|
+//! | Unknown | 0 | 6 (Info) |
+//! | Low | 3 | 5 (Notice) |
+//! | Medium | 5 | 4 (Warning) |
+//! | High | 8 | 3 (Error) |
+//! | Critical | 10 | 2 (Critical) |
+//!
+//! # Feature Flags
+//!
+//! - `http` - Enable HTTP transport (required for Splunk HEC, Elastic, etc.)
+//! - `audit` - Enable armature-audit integration
+//! - `di` - Enable dependency injection support
+//! - `full` - Enable all features
+
+pub mod client;
+pub mod config;
+pub mod error;
+pub mod event;
+pub mod format;
+pub mod provider;
+
+pub use client::*;
+pub use config::*;
+pub use error::*;
+pub use event::*;
+pub use format::{get_formatter, EventFormatter};
+pub use provider::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_module_exports() {
+        // Ensure all public types are accessible
+        let _ = SiemEvent::new("test");
+        let _ = SiemSeverity::Low;
+        let _ = EventCategory::Authentication;
+        let _ = EventOutcome::Success;
+        let _ = SiemProvider::Splunk;
+        let _ = EventFormat::Json;
+    }
+
+    #[test]
+    fn test_event_creation() {
+        let event = SiemEvent::new("user.login")
+            .category(EventCategory::Authentication)
+            .severity(SiemSeverity::Low)
+            .outcome(EventOutcome::Success)
+            .src_ip("192.168.1.100")
+            .src_user("alice")
+            .action("login")
+            .message("User logged in successfully");
+
+        assert_eq!(event.event_type, "user.login");
+        assert_eq!(event.category, EventCategory::Authentication);
+        assert_eq!(event.severity, SiemSeverity::Low);
+        assert_eq!(event.src_user, Some("alice".to_string()));
+    }
+
+    #[test]
+    fn test_splunk_config_builder() {
+        let config = SplunkConfig::hec("https://splunk.example.com:8088")
+            .token("test-token")
+            .index("main")
+            .source_type("armature:security")
+            .build()
+            .unwrap();
+
+        assert_eq!(config.provider, SiemProvider::Splunk);
+        assert_eq!(config.format, EventFormat::Json);
+        assert!(config.endpoint.contains("/services/collector"));
+    }
+
+    #[test]
+    fn test_format_selection() {
+        let formatter = get_formatter(EventFormat::Cef);
+        assert_eq!(formatter.content_type(), "text/plain");
+
+        let formatter = get_formatter(EventFormat::Json);
+        assert_eq!(formatter.content_type(), "application/json");
+    }
+}

--- a/armature-siem/src/provider.rs
+++ b/armature-siem/src/provider.rs
@@ -1,0 +1,363 @@
+//! SIEM provider-specific configurations and helpers
+//!
+//! This module provides pre-configured builders for popular SIEM systems.
+
+use crate::config::{EventFormat, SiemConfig, SiemConfigBuilder, SiemProvider, Transport};
+
+/// Splunk configuration helper
+pub struct SplunkConfig;
+
+impl SplunkConfig {
+    /// Create a Splunk HEC configuration
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use armature_siem::*;
+    ///
+    /// let config = SplunkConfig::hec("https://splunk.example.com:8088")
+    ///     .token("your-hec-token")
+    ///     .index("security")
+    ///     .source_type("armature:security")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn hec(endpoint: impl Into<String>) -> SiemConfigBuilder {
+        let mut endpoint_str = endpoint.into();
+        if !endpoint_str.ends_with("/services/collector") && !endpoint_str.ends_with("/services/collector/event") {
+            if endpoint_str.ends_with('/') {
+                endpoint_str.push_str("services/collector");
+            } else {
+                endpoint_str.push_str("/services/collector");
+            }
+        }
+
+        SiemConfig::builder()
+            .provider(SiemProvider::Splunk)
+            .endpoint(endpoint_str)
+            .format(EventFormat::Json)
+            .transport(Transport::Https)
+    }
+
+    /// Create a Splunk syslog configuration
+    pub fn syslog(endpoint: impl Into<String>) -> SiemConfigBuilder {
+        SiemConfig::builder()
+            .provider(SiemProvider::Splunk)
+            .endpoint(endpoint)
+            .format(EventFormat::Syslog)
+            .transport(Transport::Tcp)
+    }
+}
+
+/// Elasticsearch/Elastic Security configuration helper
+pub struct ElasticConfig;
+
+impl ElasticConfig {
+    /// Create an Elasticsearch configuration
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use armature_siem::*;
+    ///
+    /// let config = ElasticConfig::new("https://elastic.example.com:9200")
+    ///     .index("security-events")
+    ///     .basic_auth("elastic", "password")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn new(endpoint: impl Into<String>) -> SiemConfigBuilder {
+        SiemConfig::builder()
+            .provider(SiemProvider::Elastic)
+            .endpoint(endpoint)
+            .format(EventFormat::Ecs)
+            .transport(Transport::Https)
+    }
+
+    /// Create an Elastic Cloud configuration
+    pub fn cloud(cloud_id: impl Into<String>, api_key: impl Into<String>) -> SiemConfigBuilder {
+        // In a real implementation, we'd decode the cloud_id to get the endpoint
+        // For now, just use it as the endpoint
+        SiemConfig::builder()
+            .provider(SiemProvider::Elastic)
+            .endpoint(cloud_id)
+            .token(api_key)
+            .format(EventFormat::Ecs)
+            .transport(Transport::Https)
+    }
+}
+
+/// IBM QRadar configuration helper
+pub struct QRadarConfig;
+
+impl QRadarConfig {
+    /// Create a QRadar LEEF configuration over TCP
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use armature_siem::*;
+    ///
+    /// let config = QRadarConfig::leef("qradar.example.com:514")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn leef(endpoint: impl Into<String>) -> SiemConfigBuilder {
+        SiemConfig::builder()
+            .provider(SiemProvider::QRadar)
+            .endpoint(endpoint)
+            .format(EventFormat::Leef)
+            .transport(Transport::Tcp)
+    }
+
+    /// Create a QRadar syslog configuration
+    pub fn syslog(endpoint: impl Into<String>) -> SiemConfigBuilder {
+        SiemConfig::builder()
+            .provider(SiemProvider::QRadar)
+            .endpoint(endpoint)
+            .format(EventFormat::Syslog)
+            .transport(Transport::Tcp)
+    }
+}
+
+/// Microsoft Sentinel configuration helper
+pub struct SentinelConfig;
+
+impl SentinelConfig {
+    /// Create a Microsoft Sentinel configuration
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use armature_siem::*;
+    ///
+    /// let config = SentinelConfig::new(
+    ///     "workspace-id",
+    ///     "shared-key"
+    /// ).build().unwrap();
+    /// ```
+    pub fn new(workspace_id: impl Into<String>, shared_key: impl Into<String>) -> SiemConfigBuilder {
+        let workspace = workspace_id.into();
+        let endpoint = format!(
+            "https://{}.ods.opinsights.azure.com/api/logs?api-version=2016-04-01",
+            workspace
+        );
+
+        SiemConfig::builder()
+            .provider(SiemProvider::Sentinel)
+            .endpoint(endpoint)
+            .token(shared_key)
+            .format(EventFormat::Json)
+            .transport(Transport::Https)
+    }
+}
+
+/// Sumo Logic configuration helper
+pub struct SumoLogicConfig;
+
+impl SumoLogicConfig {
+    /// Create a Sumo Logic HTTP Source configuration
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use armature_siem::*;
+    ///
+    /// let config = SumoLogicConfig::http_source(
+    ///     "https://collectors.sumologic.com/receiver/v1/http/TOKEN"
+    /// ).build().unwrap();
+    /// ```
+    pub fn http_source(endpoint: impl Into<String>) -> SiemConfigBuilder {
+        SiemConfig::builder()
+            .provider(SiemProvider::SumoLogic)
+            .endpoint(endpoint)
+            .format(EventFormat::Json)
+            .transport(Transport::Https)
+    }
+}
+
+/// Datadog configuration helper
+pub struct DatadogConfig;
+
+impl DatadogConfig {
+    /// Create a Datadog configuration
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use armature_siem::*;
+    ///
+    /// let config = DatadogConfig::new("your-api-key")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn new(api_key: impl Into<String>) -> SiemConfigBuilder {
+        SiemConfig::builder()
+            .provider(SiemProvider::Datadog)
+            .endpoint("https://http-intake.logs.datadoghq.com/api/v2/logs")
+            .token(api_key)
+            .format(EventFormat::Json)
+            .transport(Transport::Https)
+    }
+
+    /// Create a Datadog EU configuration
+    pub fn eu(api_key: impl Into<String>) -> SiemConfigBuilder {
+        SiemConfig::builder()
+            .provider(SiemProvider::Datadog)
+            .endpoint("https://http-intake.logs.datadoghq.eu/api/v2/logs")
+            .token(api_key)
+            .format(EventFormat::Json)
+            .transport(Transport::Https)
+    }
+}
+
+/// ArcSight configuration helper
+pub struct ArcSightConfig;
+
+impl ArcSightConfig {
+    /// Create an ArcSight CEF configuration
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use armature_siem::*;
+    ///
+    /// let config = ArcSightConfig::cef("arcsight.example.com:514")
+    ///     .cef_vendor("MyCompany")
+    ///     .cef_product("MyApp")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn cef(endpoint: impl Into<String>) -> SiemConfigBuilder {
+        SiemConfig::builder()
+            .provider(SiemProvider::ArcSight)
+            .endpoint(endpoint)
+            .format(EventFormat::Cef)
+            .transport(Transport::Tcp)
+    }
+
+    /// Create an ArcSight syslog configuration
+    pub fn syslog(endpoint: impl Into<String>) -> SiemConfigBuilder {
+        SiemConfig::builder()
+            .provider(SiemProvider::ArcSight)
+            .endpoint(endpoint)
+            .format(EventFormat::Syslog)
+            .transport(Transport::Udp)
+    }
+}
+
+/// Generic syslog configuration helper
+pub struct SyslogConfig;
+
+impl SyslogConfig {
+    /// Create a UDP syslog configuration
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use armature_siem::*;
+    ///
+    /// let config = SyslogConfig::udp("syslog.example.com:514")
+    ///     .app_name("myapp")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn udp(endpoint: impl Into<String>) -> SiemConfigBuilder {
+        SiemConfig::builder()
+            .provider(SiemProvider::Syslog)
+            .endpoint(endpoint)
+            .format(EventFormat::Syslog)
+            .transport(Transport::Udp)
+    }
+
+    /// Create a TCP syslog configuration
+    pub fn tcp(endpoint: impl Into<String>) -> SiemConfigBuilder {
+        SiemConfig::builder()
+            .provider(SiemProvider::Syslog)
+            .endpoint(endpoint)
+            .format(EventFormat::Syslog)
+            .transport(Transport::Tcp)
+    }
+
+    /// Create a TLS syslog configuration
+    pub fn tls(endpoint: impl Into<String>) -> SiemConfigBuilder {
+        SiemConfig::builder()
+            .provider(SiemProvider::Syslog)
+            .endpoint(endpoint)
+            .format(EventFormat::Syslog)
+            .transport(Transport::Tls)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_splunk_hec_config() {
+        let config = SplunkConfig::hec("https://splunk.example.com:8088")
+            .token("test-token")
+            .index("main")
+            .build()
+            .unwrap();
+
+        assert_eq!(config.provider, SiemProvider::Splunk);
+        assert!(config.endpoint.contains("/services/collector"));
+        assert_eq!(config.token, Some("test-token".to_string()));
+        assert_eq!(config.format, EventFormat::Json);
+    }
+
+    #[test]
+    fn test_elastic_config() {
+        let config = ElasticConfig::new("https://elastic.example.com:9200")
+            .index("security")
+            .build()
+            .unwrap();
+
+        assert_eq!(config.provider, SiemProvider::Elastic);
+        assert_eq!(config.format, EventFormat::Ecs);
+    }
+
+    #[test]
+    fn test_qradar_config() {
+        let config = QRadarConfig::leef("qradar.example.com:514")
+            .build()
+            .unwrap();
+
+        assert_eq!(config.provider, SiemProvider::QRadar);
+        assert_eq!(config.format, EventFormat::Leef);
+        assert_eq!(config.transport, Transport::Tcp);
+    }
+
+    #[test]
+    fn test_sentinel_config() {
+        let config = SentinelConfig::new("workspace-123", "shared-key")
+            .build()
+            .unwrap();
+
+        assert_eq!(config.provider, SiemProvider::Sentinel);
+        assert!(config.endpoint.contains("opinsights.azure.com"));
+    }
+
+    #[test]
+    fn test_datadog_config() {
+        let config = DatadogConfig::new("api-key")
+            .build()
+            .unwrap();
+
+        assert_eq!(config.provider, SiemProvider::Datadog);
+        assert!(config.endpoint.contains("datadoghq.com"));
+    }
+
+    #[test]
+    fn test_syslog_config() {
+        let config = SyslogConfig::udp("syslog.example.com:514")
+            .app_name("test-app")
+            .build()
+            .unwrap();
+
+        assert_eq!(config.provider, SiemProvider::Syslog);
+        assert_eq!(config.format, EventFormat::Syslog);
+        assert_eq!(config.transport, Transport::Udp);
+    }
+}

--- a/armature-siem/tests/integration.rs
+++ b/armature-siem/tests/integration.rs
@@ -1,0 +1,286 @@
+//! Integration tests for armature-siem
+
+use armature_siem::*;
+
+#[test]
+fn test_siem_event_builder() {
+    let event = SiemEvent::new("security.alert")
+        .category(EventCategory::IntrusionDetection)
+        .severity(SiemSeverity::Critical)
+        .outcome(EventOutcome::Success)
+        .src_ip("10.0.0.100")
+        .src_port(12345)
+        .dst_ip("192.168.1.1")
+        .dst_port(443)
+        .src_user("attacker")
+        .protocol("TCP")
+        .action("blocked")
+        .message("Suspicious connection blocked")
+        .threat_indicator("ip", "10.0.0.100")
+        .metadata("rule_id", serde_json::json!("RULE-001"))
+        .metadata("confidence", serde_json::json!(0.95));
+
+    assert_eq!(event.event_type, "security.alert");
+    assert_eq!(event.severity, SiemSeverity::Critical);
+    assert_eq!(event.src_ip, Some("10.0.0.100".to_string()));
+    assert_eq!(event.dst_port, Some(443));
+    assert_eq!(event.threat_indicator, Some("10.0.0.100".to_string()));
+    assert_eq!(event.metadata.len(), 2);
+}
+
+#[test]
+fn test_cef_formatting() {
+    let event = SiemEvent::new("user.login")
+        .category(EventCategory::Authentication)
+        .severity(SiemSeverity::Low)
+        .outcome(EventOutcome::Success)
+        .src_ip("192.168.1.100")
+        .src_user("alice")
+        .action("login")
+        .message("User logged in");
+
+    let config = SiemConfig {
+        provider: SiemProvider::ArcSight,
+        cef_vendor: "TestVendor".to_string(),
+        cef_product: "TestProduct".to_string(),
+        cef_version: "1.0".to_string(),
+        ..Default::default()
+    };
+
+    let formatter = get_formatter(EventFormat::Cef);
+    let result = formatter.format(&event, &config).unwrap();
+
+    assert!(result.starts_with("CEF:0|TestVendor|TestProduct|1.0|"));
+    assert!(result.contains("src=192.168.1.100"));
+    assert!(result.contains("suser=alice"));
+    assert!(result.contains("|3|")); // Severity 3 for Low
+}
+
+#[test]
+fn test_leef_formatting() {
+    let event = SiemEvent::new("auth.failure")
+        .category(EventCategory::Authentication)
+        .severity(SiemSeverity::High)
+        .outcome(EventOutcome::Failure)
+        .src_ip("10.0.0.50")
+        .src_user("badactor")
+        .action("login")
+        .message("Authentication failed");
+
+    let config = SiemConfig {
+        provider: SiemProvider::QRadar,
+        cef_vendor: "Armature".to_string(),
+        cef_product: "Security".to_string(),
+        cef_version: "1.0".to_string(),
+        ..Default::default()
+    };
+
+    let formatter = get_formatter(EventFormat::Leef);
+    let result = formatter.format(&event, &config).unwrap();
+
+    assert!(result.starts_with("LEEF:2.0|Armature|Security|1.0|auth.failure|"));
+    assert!(result.contains("src=10.0.0.50"));
+    assert!(result.contains("usrName=badactor"));
+    assert!(result.contains("outcome=failure"));
+}
+
+#[test]
+fn test_syslog_formatting() {
+    let event = SiemEvent::new("session.created")
+        .category(EventCategory::Session)
+        .severity(SiemSeverity::Low)
+        .outcome(EventOutcome::Success)
+        .src_user("testuser")
+        .action("create")
+        .message("Session started");
+
+    let config = SiemConfig {
+        provider: SiemProvider::Syslog,
+        app_name: "testapp".to_string(),
+        syslog_facility: SyslogFacility::Local0,
+        ..Default::default()
+    };
+
+    let formatter = get_formatter(EventFormat::Syslog);
+    let result = formatter.format(&event, &config).unwrap();
+
+    // Local0 (16) * 8 + Notice (5) = 133
+    assert!(result.starts_with("<133>1 "));
+    assert!(result.contains("testapp"));
+    assert!(result.contains("session.created"));
+    assert!(result.contains("[armature@32473"));
+}
+
+#[test]
+fn test_ecs_formatting() {
+    let event = SiemEvent::new("http.request")
+        .category(EventCategory::Web)
+        .severity(SiemSeverity::Low)
+        .outcome(EventOutcome::Success)
+        .src_ip("192.168.1.50")
+        .http_method("GET")
+        .http_status(200)
+        .url("/api/users")
+        .user_agent("Mozilla/5.0")
+        .action("request");
+
+    let config = SiemConfig::default();
+
+    let formatter = get_formatter(EventFormat::Ecs);
+    let result = formatter.format(&event, &config).unwrap();
+
+    let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+    assert!(parsed.get("@timestamp").is_some());
+    assert_eq!(parsed["event"]["action"], "request");
+    assert_eq!(parsed["source"]["ip"], "192.168.1.50");
+    assert_eq!(parsed["http"]["request"]["method"], "GET");
+    assert_eq!(parsed["http"]["response"]["status_code"], 200);
+    assert_eq!(parsed["ecs"]["version"], "8.11");
+}
+
+#[test]
+fn test_json_formatting_splunk() {
+    let event = SiemEvent::new("test.event")
+        .category(EventCategory::Web)
+        .action("test");
+
+    let config = SiemConfig {
+        provider: SiemProvider::Splunk,
+        source: Some("armature".to_string()),
+        source_type: Some("security".to_string()),
+        index: Some("main".to_string()),
+        ..Default::default()
+    };
+
+    let formatter = get_formatter(EventFormat::Json);
+    let result = formatter.format(&event, &config).unwrap();
+
+    let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+    assert!(parsed.get("time").is_some());
+    assert!(parsed.get("host").is_some());
+    assert_eq!(parsed["source"], "armature");
+    assert_eq!(parsed["sourcetype"], "security");
+    assert!(parsed.get("event").is_some());
+}
+
+#[test]
+fn test_provider_configs() {
+    // Test Splunk HEC config
+    let splunk_config = SplunkConfig::hec("https://splunk.example.com:8088")
+        .token("test-token")
+        .build()
+        .unwrap();
+    assert_eq!(splunk_config.provider, SiemProvider::Splunk);
+    assert!(splunk_config.endpoint.contains("/services/collector"));
+
+    // Test Elastic config
+    let elastic_config = ElasticConfig::new("https://elastic.example.com:9200")
+        .index("security")
+        .build()
+        .unwrap();
+    assert_eq!(elastic_config.provider, SiemProvider::Elastic);
+    assert_eq!(elastic_config.format, EventFormat::Ecs);
+
+    // Test QRadar config
+    let qradar_config = QRadarConfig::leef("qradar.example.com:514")
+        .build()
+        .unwrap();
+    assert_eq!(qradar_config.provider, SiemProvider::QRadar);
+    assert_eq!(qradar_config.format, EventFormat::Leef);
+
+    // Test Sentinel config
+    let sentinel_config = SentinelConfig::new("workspace-id", "shared-key")
+        .build()
+        .unwrap();
+    assert_eq!(sentinel_config.provider, SiemProvider::Sentinel);
+    assert!(sentinel_config.endpoint.contains("opinsights.azure.com"));
+
+    // Test Datadog config
+    let datadog_config = DatadogConfig::new("api-key")
+        .build()
+        .unwrap();
+    assert_eq!(datadog_config.provider, SiemProvider::Datadog);
+    assert!(datadog_config.endpoint.contains("datadoghq.com"));
+}
+
+#[test]
+fn test_config_validation() {
+    // Empty endpoint should fail
+    let result = SiemConfig::builder()
+        .provider(SiemProvider::Splunk)
+        .build();
+    assert!(result.is_err());
+
+    // Wrong transport/endpoint combo should fail
+    let result = SiemConfig::builder()
+        .provider(SiemProvider::Splunk)
+        .endpoint("splunk.example.com") // Missing http://
+        .transport(Transport::Https)
+        .build();
+    assert!(result.is_err());
+
+    // Valid config should succeed
+    let result = SiemConfig::builder()
+        .provider(SiemProvider::Splunk)
+        .endpoint("https://splunk.example.com:8088")
+        .token("test")
+        .build();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_severity_mappings() {
+    // CEF severity (0-10)
+    assert_eq!(SiemSeverity::Unknown.as_cef_severity(), 0);
+    assert_eq!(SiemSeverity::Low.as_cef_severity(), 3);
+    assert_eq!(SiemSeverity::Medium.as_cef_severity(), 5);
+    assert_eq!(SiemSeverity::High.as_cef_severity(), 8);
+    assert_eq!(SiemSeverity::Critical.as_cef_severity(), 10);
+
+    // Syslog severity (0-7, lower is more severe)
+    assert_eq!(SiemSeverity::Unknown.as_syslog_severity(), 6); // Info
+    assert_eq!(SiemSeverity::Low.as_syslog_severity(), 5);     // Notice
+    assert_eq!(SiemSeverity::Medium.as_syslog_severity(), 4);  // Warning
+    assert_eq!(SiemSeverity::High.as_syslog_severity(), 3);    // Error
+    assert_eq!(SiemSeverity::Critical.as_syslog_severity(), 2); // Critical
+}
+
+#[test]
+fn test_batch_formatting() {
+    let events = vec![
+        SiemEvent::new("event.1").action("test1"),
+        SiemEvent::new("event.2").action("test2"),
+        SiemEvent::new("event.3").action("test3"),
+    ];
+
+    let config = SiemConfig {
+        provider: SiemProvider::Splunk,
+        ..Default::default()
+    };
+
+    let formatter = get_formatter(EventFormat::Json);
+    let result = formatter.format_batch(&events, &config).unwrap();
+
+    // Splunk expects newline-delimited JSON
+    let lines: Vec<&str> = result.lines().collect();
+    assert_eq!(lines.len(), 3);
+}
+
+#[tokio::test]
+async fn test_memory_transport() {
+    let transport = MemoryTransport::new();
+
+    transport.send("message 1", "text/plain").await.unwrap();
+    transport.send("message 2", "text/plain").await.unwrap();
+
+    let messages = transport.get_messages().await;
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0], "message 1");
+    assert_eq!(messages[1], "message 2");
+
+    transport.clear().await;
+    let messages = transport.get_messages().await;
+    assert_eq!(messages.len(), 0);
+}


### PR DESCRIPTION
## Summary

This PR integrates the [mq-bridge](https://github.com/marcomq/mq-bridge) crate as an optional backend for `armature-messaging`, providing a unified transport layer for cross-protocol messaging.

## Related Issue

Closes #93 - Potential integration of mq-bridge with Armature-messaging

## Changes

### New Features

- **MqBridgeBroker**: Implements the `MessageBroker` trait using mq-bridge endpoints
- **MqBridgeConfig**: Configuration builder for various mq-bridge endpoint types
- **MqBridgeRoute**: Helper for creating message processing routes/pipelines
- **Message conversion utilities**: `to_canonical()` and `from_canonical()` for converting between armature's `Message` and mq-bridge's `CanonicalMessage`

### Supported Backends (via feature flags)

| Feature | Backend |
|---------|---------|
| `mq-bridge` | Base integration with memory transport |
| `mq-bridge-kafka` | Apache Kafka |
| `mq-bridge-amqp` | AMQP (RabbitMQ) |
| `mq-bridge-nats` | NATS |
| `mq-bridge-mqtt` | MQTT |
| `mq-bridge-http` | HTTP |
| `mq-bridge-full` | All backends |

### Benefits

1. **Unified Transport Layer**: Use mq-bridge's `CanonicalMessage` for cross-protocol messaging
2. **Middleware Support**: Leverage mq-bridge's retry, DLQ, and deduplication middleware
3. **Route-based Architecture**: Define message routes with handlers and transformations
4. **Protocol Bridging**: Connect systems speaking different protocols (e.g., MQTT to Kafka)

## Testing

All existing tests pass plus new tests for mq-bridge integration.

## Credits

Thanks to @marcomq for creating mq-bridge and suggesting this integration!