### PR TITLE
fix(seaorm): gate the postgres integration test behind sqlx-postgres

### DIFF
--- a/armature-seaorm/tests/transaction_options.rs
+++ b/armature-seaorm/tests/transaction_options.rs
@@ -6,6 +6,13 @@
 //! Self-skips when Docker is unavailable via
 //! `armature_testkit::skip_if_no_docker!`, which instead fails the test when
 //! `ARMATURE_REQUIRE_DOCKER=1` is set (CI).
+//!
+//! Gated behind the `sqlx-postgres` feature: it connects to a `postgres://`
+//! URL, so without the Postgres driver compiled in (e.g. the CI
+//! `--no-default-features` "minimal features" job) `Database::connect` would
+//! fail with "no supporting driver". The feature gate excludes the test from
+//! those runs instead of failing them.
+#![cfg(feature = "sqlx-postgres")]
 
 use armature_seaorm::{
     Database, DatabaseConfig, IsolationLevel, TransactionExt, TransactionOptions,


### PR DESCRIPTION
## Problem
`begin_transaction_with_options_applies_isolation_and_read_only` connects to a `postgres://` URL but was only Docker-gated, not feature-gated. The CI **Test member crates (armature-seaorm)** job runs `--no-default-features` (dropping the `sqlx-postgres` driver from `default`) with `ARMATURE_REQUIRE_DOCKER=1`: the container starts but `Database::connect` fails with *"the connection string has no supporting driver"* — a red check unrelated to any code change.

## Fix
Add `#![cfg(feature = "sqlx-postgres")]` to the test file so it's excluded from driver-less runs (mirroring how the Redis container tests are gated behind the `redis` feature), instead of failing them.

## Verified
- `--no-default-features`: test reports `0 tests` (correctly skipped).
- Default features + Docker: still runs and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)