### PR TITLE
chore: merge release/0.3.0 back into develop

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -26,6 +26,21 @@ ignore = [
     # Action: Will address when upgrading opentelemetry ecosystem to 0.31.x
     "RUSTSEC-2024-0437",
 
+    # RUSTSEC-2026-0049 / 0098 / 0099 / 0104: rustls-webpki < 0.103.x - CRL
+    # parsing panics and related certificate-verification issues.
+    # Status: Old webpki versions are pinned by external optional integrations:
+    #   - rustls 0.21 via mq-bridge's internal aws-config (default features)
+    #   - rustls 0.22 via rumqttc 0.25 (latest release; no fixed version exists)
+    # First-party AWS crates now use default-https-client (rustls 0.23 /
+    # webpki 0.103, which is patched). The vulnerable versions only enter
+    # builds that opt into the mq-bridge/mqtt integrations.
+    # Action: Re-check when mq-bridge updates its aws-config defaults and
+    # rumqttc releases a rustls >= 0.23 version.
+    "RUSTSEC-2026-0049",
+    "RUSTSEC-2026-0098",
+    "RUSTSEC-2026-0099",
+    "RUSTSEC-2026-0104",
+
     #
     # === UNMAINTAINED CRATE WARNINGS ===
     #

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Comment benchmark results on PR
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,7 +492,7 @@ jobs:
       - name: Generate coverage
         run: cargo llvm-cov --features full-with-saml --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/flamegraph.yml
+++ b/.github/workflows/flamegraph.yml
@@ -171,7 +171,7 @@ jobs:
 
       - name: Comment flamegraph on PR
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           path: artifacts/
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: Release ${{ github.ref_name }}
           body: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,16 +22,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # SAML (armature-auth's `saml` feature -> samael -> openssl-sys +
+          # system xmlsec1) has never been built/tested on anything but
+          # Linux glibc in this project (see the Linux-only `test-saml` job
+          # in ci.yml) -- cross-compiling xmlsec1/openssl for musl, or
+          # building them on Windows/macOS, is unproven and out of scope
+          # here. Only the gnu target builds with every feature (including
+          # saml); the rest build every feature EXCEPT saml.
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+            feature_flag: --all-features
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+            feature_flag: --features full,messaging-kafka,messaging-rabbitmq,messaging-nats,messaging-full,simd-json,memory-profiling
           - target: x86_64-apple-darwin
             os: macos-latest
+            feature_flag: --features full,messaging-kafka,messaging-rabbitmq,messaging-nats,messaging-full,simd-json,memory-profiling
           - target: aarch64-apple-darwin
             os: macos-latest
+            feature_flag: --features full,messaging-kafka,messaging-rabbitmq,messaging-nats,messaging-full,simd-json,memory-profiling
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+            feature_flag: --features full,messaging-kafka,messaging-rabbitmq,messaging-nats,messaging-full,simd-json,memory-profiling
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -43,8 +55,17 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
+      # SAML (xmlsec1) and Kafka (rdkafka-sys, via libcurl) system deps --
+      # only needed on the gnu target, which is the only one building with
+      # --all-features (see matrix comment above).
+      - name: Install SAML/Kafka system dependencies (Linux gnu)
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl libcurl4-openssl-dev pkg-config
+
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }} --all-features
+        run: cargo build --release --target ${{ matrix.target }} ${{ matrix.feature_flag }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-29
+
 ### Security
 
 #### Version bumps — code-review follow-up (`armature-security`, `armature-jwt`, `armature-session`, `armature-mcp`, `armature-auth`, `armature-core`)
@@ -988,6 +990,7 @@ See [docs/migration.md](docs/migration.md) for detailed upgrade instructions bet
 
 ---
 
-[Unreleased]: https://github.com/quinnjr/armature/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/quinnjr/armature/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/quinnjr/armature/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/quinnjr/armature/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/quinnjr/armature/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ homepage = "https://quinnjr.github.io/armature"
 
 [package]
 name = "armature-framework"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.94.1"
 autobenches = false  # Disable auto-discovery, use explicit [[bench]] only

--- a/armature-i18n/Cargo.toml
+++ b/armature-i18n/Cargo.toml
@@ -16,7 +16,7 @@ default = ["fluent"]
 # Use Fluent for message formatting
 fluent = ["dep:fluent", "dep:fluent-bundle", "dep:fluent-syntax", "dep:intl-memoizer", "dep:unic-langid"]
 # ICU-based formatting
-icu = ["dep:icu_locid", "dep:icu_datetime", "dep:icu_decimal", "dep:icu_plurals", "dep:icu_calendar"]
+icu = ["dep:icu_locale_core", "dep:icu_datetime", "dep:icu_decimal", "dep:icu_plurals", "dep:icu_calendar"]
 # Full features
 full = ["fluent", "icu"]
 
@@ -36,7 +36,7 @@ intl-memoizer = { version = "0.5", optional = true }
 unic-langid = { version = "0.9", optional = true }
 
 # ICU (International Components for Unicode)
-icu_locid = { version = "2.0", optional = true }
+icu_locale_core = { version = "2.2", optional = true }
 icu_datetime = { version = "2.2", optional = true }
 icu_decimal = { version = "2.2", optional = true }
 icu_plurals = { version = "2.2", optional = true }

--- a/armature-messaging/src/mq_bridge.rs
+++ b/armature-messaging/src/mq_bridge.rs
@@ -238,10 +238,9 @@ impl MqBridgeConfig {
             MqEndpointType::Http => {
                 panic!("HTTP support requires 'mq-bridge-http' feature")
             }
-            MqEndpointType::File => Endpoint::new(EndpointType::File(FileConfig {
-                path: self.topic.clone(),
-                ..Default::default()
-            })),
+            MqEndpointType::File => {
+                Endpoint::new(EndpointType::File(FileConfig::new(self.topic.clone())))
+            }
         }
     }
 }

--- a/armature-opensearch/Cargo.toml
+++ b/armature-opensearch/Cargo.toml
@@ -38,7 +38,7 @@ async-trait = "0.1"
 thiserror = "2.0"
 
 # Optional AWS auth
-aws-config = { version = "1", optional = true }
+aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"], optional = true }
 aws-credential-types = { version = "1", optional = true }
 aws-types = { version = "1", optional = true }
 

--- a/armature-push/Cargo.toml
+++ b/armature-push/Cargo.toml
@@ -21,7 +21,12 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # HTTP client
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "form"] }
+reqwest = { version = "0.13", default-features = false, features = [
+    "json",
+    "form",
+    "rustls",
+    "http2",
+] }
 
 # Error handling
 thiserror = "2.0"
@@ -64,4 +69,3 @@ web-push = ["dep:web-push"]
 fcm = ["jsonwebtoken"]
 apns = ["jsonwebtoken", "p256", "reqwest/http2"]
 all = ["web-push", "fcm", "apns"]
-

--- a/armature-testkit/src/acme.rs
+++ b/armature-testkit/src/acme.rs
@@ -66,7 +66,23 @@ impl PebbleCa {
             .status()
             .expect("run docker cp for pebble minica");
         assert!(status.success(), "docker cp of pebble.minica.pem failed");
-        let pem = std::fs::read(&dest).expect("read pebble minica pem");
+
+        // `docker cp` can return before the destination file is visible to a
+        // subsequent read on a loaded/overlay host filesystem (observed as
+        // intermittent CI failures) -- retry briefly rather than assume the
+        // first read always sees it.
+        let mut attempt = 0;
+        let pem = loop {
+            match std::fs::read(&dest) {
+                Ok(bytes) if !bytes.is_empty() => break bytes,
+                Ok(_) | Err(_) if attempt < 20 => {
+                    attempt += 1;
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+                Ok(bytes) => break bytes,
+                Err(e) => panic!("read pebble minica pem after {attempt} retries: {e}"),
+            }
+        };
         let _ = std::fs::remove_file(&dest);
         pem
     }

--- a/armature-testkit/src/acme.rs
+++ b/armature-testkit/src/acme.rs
@@ -55,7 +55,20 @@ impl PebbleCa {
     /// The image is distroless, so the file is extracted with `docker cp`
     /// rather than an in-container shell.
     pub fn management_ca_pem(&self) -> Vec<u8> {
-        let dest = std::env::temp_dir().join(format!("pebble-minica-{}.pem", std::process::id()));
+        // `std::process::id()` alone is not a unique destination: Rust's
+        // test harness runs every test in one process across multiple
+        // threads, so two tests calling this concurrently raced on the
+        // same path -- one test's cleanup `remove_file` deleted the file
+        // out from under the other's read, surfacing as an intermittent
+        // "No such file or directory" failure. Add a per-call counter to
+        // guarantee a distinct path for every invocation, concurrent or
+        // not.
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let call_id = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let dest = std::env::temp_dir().join(format!(
+            "pebble-minica-{}-{call_id}.pem",
+            std::process::id()
+        ));
         let status = std::process::Command::new("docker")
             .arg("cp")
             .arg(format!(
@@ -66,23 +79,7 @@ impl PebbleCa {
             .status()
             .expect("run docker cp for pebble minica");
         assert!(status.success(), "docker cp of pebble.minica.pem failed");
-
-        // `docker cp` can return before the destination file is visible to a
-        // subsequent read on a loaded/overlay host filesystem (observed as
-        // intermittent CI failures) -- retry briefly rather than assume the
-        // first read always sees it.
-        let mut attempt = 0;
-        let pem = loop {
-            match std::fs::read(&dest) {
-                Ok(bytes) if !bytes.is_empty() => break bytes,
-                Ok(_) | Err(_) if attempt < 20 => {
-                    attempt += 1;
-                    std::thread::sleep(std::time::Duration::from_millis(50));
-                }
-                Ok(bytes) => break bytes,
-                Err(e) => panic!("read pebble minica pem after {attempt} retries: {e}"),
-            }
-        };
+        let pem = std::fs::read(&dest).expect("read pebble minica pem");
         let _ = std::fs::remove_file(&dest);
         pem
     }

--- a/benchmarks/comparison/go_fiber/go.mod
+++ b/benchmarks/comparison/go_fiber/go.mod
@@ -2,7 +2,7 @@ module fiber-bench
 
 go 1.21
 
-require github.com/gofiber/fiber/v2 v2.52.9
+require github.com/gofiber/fiber/v2 v2.52.13
 
 require (
 	github.com/andybalholm/brotli v1.1.0 // indirect

--- a/benchmarks/comparison/go_fiber/go.sum
+++ b/benchmarks/comparison/go_fiber/go.sum
@@ -1,7 +1,7 @@
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
-github.com/gofiber/fiber/v2 v2.52.9 h1:YjKl5DOiyP3j0mO61u3NTmK7or8GzzWzCFzkboyP5cw=
-github.com/gofiber/fiber/v2 v2.52.9/go.mod h1:YEcBbO/FB+5M1IZNBP9FO3J9281zgPAreiI1oqg8nDw=
+github.com/gofiber/fiber/v2 v2.52.13 h1:TOKP64iqC9b5P49VrBW5tHhUOvDyrtJ0xePEfzJbCbk=
+github.com/gofiber/fiber/v2 v2.52.13/go.mod h1:YEcBbO/FB+5M1IZNBP9FO3J9281zgPAreiI1oqg8nDw=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=

--- a/templates/api-full/Cargo.toml
+++ b/templates/api-full/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.94.1"
 # *different*, unrelated crate is published under the bare name `armature` —
 # so the dependency needs an explicit `package = "armature-framework"` or
 # Cargo will resolve the wrong crate entirely.
-armature = { package = "armature-framework", version = "0.2", features = ["auth", "jwt", "validation"] }
+armature = { package = "armature-framework", version = "0.3", features = ["auth", "jwt", "validation"] }
 # armature-core is required directly because armature's macro-expanded code references armature_core:: paths that aren't currently re-exported through the armature facade crate.
 armature-core = "0.5"
 

--- a/templates/api-minimal/Cargo.toml
+++ b/templates/api-minimal/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.94.1"
 # Published on crates.io as "armature-framework" (the name "armature" is
 # already taken by an unrelated crate); the `package` key re-aliases it to
 # `armature` so `use armature::...` in this crate's source keeps working.
-armature = { version = "0.2", package = "armature-framework" }
+armature = { version = "0.3", package = "armature-framework" }
 # armature-core is required directly because armature's macro-expanded code references armature_core:: paths that aren't currently re-exported through the armature facade crate.
 armature-core = "0.5"
 async-trait = "0.1"

--- a/templates/graphql-api/Cargo.toml
+++ b/templates/graphql-api/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.94.1"
 # unrelated, unmaintained crate) — `package = "armature-framework"` fetches
 # the right crate while keeping the local import name `armature`, matching
 # this crate's `[lib] name = "armature"`.
-armature = { package = "armature-framework", version = "0.2", features = ["graphql", "validation"] }
+armature = { package = "armature-framework", version = "0.3", features = ["graphql", "validation"] }
 # armature-core is required directly because armature's macro-expanded code references armature_core:: paths that aren't currently re-exported through the armature facade crate.
 armature-core = "0.5"
 async-graphql = { version = "7.0", features = ["chrono", "uuid"] }

--- a/templates/microservice/Cargo.toml
+++ b/templates/microservice/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.94.1"
 # package, so the real crate -- published as "armature-framework" but exposing
 # its library as `armature` (see this repo's root `[lib] name = "armature"`)
 # -- must be pulled in under an explicit `package` rename.
-armature = { package = "armature-framework", version = "0.2", features = ["queue"] }
+armature = { package = "armature-framework", version = "0.3", features = ["queue"] }
 # armature-core is required directly because armature's macro-expanded code references armature_core:: paths that aren't currently re-exported through the armature facade crate.
 armature-core = "0.5"
 async-trait = "0.1"


### PR DESCRIPTION
## Summary
Git-flow merge-back: brings `release/0.3.0`'s content into `develop` after it was merged into `main` and tagged as `v0.3.0` (PR #250).

Since `develop`'s branch protection disallows merge commits, this is composed as regular (non-merge) commits instead of a literal `git merge`:
- `6d19672` — cherry-picked via `git cherry-pick -m 2` from the original `main`↔`develop` reconciliation merge commit, capturing everything `main`'s independent dependency-maintenance commits (~108) contributed that `develop` didn't already have.
- `1dd2c34` — the `chore: release v0.3.0` version bump + CHANGELOG dating, cherry-picked directly.
- `8c03bdc` — the `fix(templates)` armature-framework version-pin fix, cherry-picked directly.

Verified the resulting tree is byte-identical to `release/0.3.0`'s tree (`git diff HEAD origin/release/0.3.0` — empty) before pushing.

## Verification
- [x] `cargo check --workspace --all-features` clean
- [x] Tree matches `release/0.3.0` exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)