### PR TITLE
fix(ci): drop Kafka from the musl release build too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,14 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             feature_flag: --all-features
+          # Kafka (rdkafka-sys, a C/C++ build via cmake) additionally needs
+          # a musl-targeted C++ cross-compiler that `musl-tools` doesn't
+          # provide -- drop `messaging-kafka`/`messaging-full` (which
+          # transitively enables kafka via armature-messaging's own `full`
+          # feature) on musl too.
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            feature_flag: --features full,messaging-kafka,messaging-rabbitmq,messaging-nats,messaging-full,simd-json,memory-profiling
+            feature_flag: --features full,messaging-rabbitmq,messaging-nats,simd-json,memory-profiling
           - target: x86_64-apple-darwin
             os: macos-latest
             feature_flag: --features full,messaging-kafka,messaging-rabbitmq,messaging-nats,messaging-full,simd-json,memory-profiling


### PR DESCRIPTION
## Summary
Follow-up to #263. After excluding SAML, the musl release build still failed: \`rdkafka-sys\`'s cmake build needs a musl-targeted C++ cross-compiler (\`x86_64-linux-musl-g++\`) that \`musl-tools\` doesn't provide. Same category of never-supported-on-this-platform gap as SAML — drops \`messaging-kafka\`/\`messaging-full\` (which transitively enables kafka) from the musl build's feature list.

## Verification
- [x] \`cargo build --release --features full,messaging-rabbitmq,messaging-nats,simd-json,memory-profiling\` — clean
- [x] \`cargo tree -i rdkafka\` confirms rdkafka is absent from the dependency graph with this feature set

## Next step after merge
Retag v0.3.0 to this commit and re-run the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)