### PR TITLE
fix(ci): drop Kafka from the musl release build too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,14 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             feature_flag: --all-features
+          # Kafka (rdkafka-sys, a C/C++ build via cmake) additionally needs
+          # a musl-targeted C++ cross-compiler that `musl-tools` doesn't
+          # provide -- drop `messaging-kafka`/`messaging-full` (which
+          # transitively enables kafka via armature-messaging's own `full`
+          # feature) on musl too.
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            feature_flag: --features full,messaging-kafka,messaging-rabbitmq,messaging-nats,messaging-full,simd-json,memory-profiling
+            feature_flag: --features full,messaging-rabbitmq,messaging-nats,simd-json,memory-profiling
           - target: x86_64-apple-darwin
             os: macos-latest
             feature_flag: --features full,messaging-kafka,messaging-rabbitmq,messaging-nats,messaging-full,simd-json,memory-profiling


### PR DESCRIPTION
## Summary
Brings the musl-Kafka release-build fix (main hotfix PR #264) into \`develop\` too, so both branches stay in sync.

## Verification
- [x] Same change as #264, already verified there (\`cargo build --release --features full,messaging-rabbitmq,messaging-nats,simd-json,memory-profiling\` clean, \`cargo tree -i rdkafka\` confirms rdkafka absent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)