### PR TITLE
fix(publish): skip workspace crates marked publish = false

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -518,7 +518,16 @@ cd "$PROJECT_ROOT"
 
 # Get all workspace members
 get_workspace_members() {
-    grep -E '^\s+"armature-' Cargo.toml | sed 's/.*"\(armature-[^"]*\)".*/\1/' | sort -u
+    local crate
+    while IFS= read -r crate; do
+        # Skip crates explicitly marked `publish = false` (e.g. internal-only
+        # test-harness crates never meant to reach crates.io) -- attempting
+        # to publish them always fails with a hard cargo error.
+        if [[ -f "$crate/Cargo.toml" ]] && grep -qE '^publish\s*=\s*false' "$crate/Cargo.toml"; then
+            continue
+        fi
+        echo "$crate"
+    done < <(grep -E '^\s+"armature-' Cargo.toml | sed 's/.*"\(armature-[^"]*\)".*/\1/' | sort -u)
 }
 
 # Get workspace dependencies for a crate


### PR DESCRIPTION
## Summary
The live v0.3.0 publish run hard-failed mid-batch on \`armature-testkit\` (\`package.publish must be set to true or a non-empty list\`) — it's explicitly \`publish = false\` (an internal-only test-harness crate never meant to reach crates.io), but \`get_workspace_members()\` greps every workspace member unconditionally, ignoring each crate's own \`publish\` field.

## Verification
- [x] \`get_workspace_members()\` output now correctly excludes \`armature-testkit\` (61 crates instead of 62)
- [x] \`./scripts/publish.sh --dry-run\` confirms the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)