### PR TITLE
chore(ci): remove GH release binary artifact uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,89 +12,25 @@ env:
 
 jobs:
   # ============================================================================
-  # BUILD RELEASE ARTIFACTS
-  # ============================================================================
-
-  build:
-    name: Build (${{ matrix.target }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # SAML (armature-auth's `saml` feature -> samael -> openssl-sys +
-          # system xmlsec1) has never been built/tested on anything but
-          # Linux glibc in this project (see the Linux-only `test-saml` job
-          # in ci.yml) -- cross-compiling xmlsec1/openssl for musl, or
-          # building them on Windows/macOS, is unproven and out of scope
-          # here. Only the gnu target builds with every feature (including
-          # saml); the rest build every feature EXCEPT saml.
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-            feature_flag: --all-features
-          # Kafka (rdkafka-sys, a C/C++ build via cmake) additionally needs
-          # a musl-targeted C++ cross-compiler that `musl-tools` doesn't
-          # provide -- drop `messaging-kafka`/`messaging-full` (which
-          # transitively enables kafka via armature-messaging's own `full`
-          # feature) on musl too.
-          - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
-            feature_flag: --features full,messaging-rabbitmq,messaging-nats,simd-json,memory-profiling
-          - target: x86_64-apple-darwin
-            os: macos-latest
-            feature_flag: --features full,messaging-kafka,messaging-rabbitmq,messaging-nats,messaging-full,simd-json,memory-profiling
-          - target: aarch64-apple-darwin
-            os: macos-latest
-            feature_flag: --features full,messaging-kafka,messaging-rabbitmq,messaging-nats,messaging-full,simd-json,memory-profiling
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-            feature_flag: --features full,messaging-kafka,messaging-rabbitmq,messaging-nats,messaging-full,simd-json,memory-profiling
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Install musl tools (Linux musl)
-        if: matrix.target == 'x86_64-unknown-linux-musl'
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
-
-      # SAML (xmlsec1) and Kafka (rdkafka-sys, via libcurl) system deps --
-      # only needed on the gnu target, which is the only one building with
-      # --all-features (see matrix comment above).
-      - name: Install SAML/Kafka system dependencies (Linux gnu)
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl libcurl4-openssl-dev pkg-config
-
-      - name: Build
-        run: cargo build --release --target ${{ matrix.target }} ${{ matrix.feature_flag }}
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: armature-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/
-
-  # ============================================================================
   # CREATE GITHUB RELEASE
+  #
+  # No binary artifacts are attached: armature-framework's root package is a
+  # library (no [[bin]] target), and the prior per-platform build+upload
+  # machinery existed solely to attach files here -- it uploaded the entire
+  # `target/<target>/release/` directory (every intermediate .o/.rlib/header
+  # from every dependency, thousands of files) as individual release assets,
+  # which was both meaningless (nothing there was a real deliverable) and
+  # unreliable (frequent transient network failures from the sheer number of
+  # uploads). The actual deliverable is the crates.io publish below.
   # ============================================================================
 
   release:
     name: Create Release
-    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v6
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@v8
-        with:
-          path: artifacts/
 
       - name: Create Release
         uses: softprops/action-gh-release@v3
@@ -113,8 +49,6 @@ jobs:
             ```
           draft: false
           prerelease: ${{ contains(github.ref_name, '-') }}
-          files: |
-            artifacts/**/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
Removes the per-platform build+upload machinery from release.yml. armature-framework's root package is a library (no \`[[bin]]\` target), and that machinery existed solely to attach files to the GitHub Release — it uploaded the *entire* \`target/<target>/release/\` directory (every intermediate \`.o\`/\`.rlib\`/header from every dependency, thousands of files) as individual release assets. Nothing there was a real deliverable, and the sheer upload count caused the transient network failures that first surfaced this during the v0.3.0 release.

"Create Release" still runs — just as release notes/changelog link with no attachments. The actual deliverable, the crates.io publish, is unaffected.

## Verification
- [x] YAML syntax validated
- [x] Clippy/fmt checks pass (no code changes, workflow-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)