### PR TITLE
feat(graphql): GraphQL subscriptions over WebSocket + NestJS-style resolver decorators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "armature-core",
     "armature-proc-macro",
     "armature-graphql",
+    "armature-graphql-macros",
     "armature-config",
     "armature-jwt",
     "armature-auth",

--- a/armature-graphql-macros/Cargo.toml
+++ b/armature-graphql-macros/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "armature-graphql-macros"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "NestJS-style resolver decorator macros for Armature GraphQL"
+keywords = ["proc-macro", "graphql", "resolver", "framework"]
+categories = ["development-tools::procedural-macro-helpers", "web-programming"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2.0", features = ["full", "extra-traits"] }
+quote = "1.0"
+proc-macro2 = "1.0"
+
+[dev-dependencies]
+armature-graphql = { path = "../armature-graphql" }
+async-graphql = "7.2.1"
+tokio = { version = "1.52", features = ["rt", "rt-multi-thread", "macros"] }
+trybuild = "1"

--- a/armature-graphql-macros/src/lib.rs
+++ b/armature-graphql-macros/src/lib.rs
@@ -56,6 +56,14 @@
 //! Untagged methods in the `impl` block (plain helpers, no `#[query]`
 //! /`#[mutation]`/`#[subscription]`) are left in place on the original type
 //! and are not exposed as GraphQL fields.
+//!
+//! # `Clone` requirement
+//!
+//! The type `#[resolver]` is applied to must implement [`Clone`]. Each
+//! generated wrapper (`#[derive(Clone)] struct Wrapper(pub OriginalType)`)
+//! derives `Clone`, which only compiles if `OriginalType: Clone` — and
+//! `async-graphql`'s `MergedObject`/`MergedSubscription` composition also
+//! requires every component to be `Clone`.
 
 mod resolver;
 
@@ -65,6 +73,9 @@ use proc_macro::TokenStream;
 /// methods into the separate `async-graphql`-driven types a
 /// `Schema<Query, Mutation, Subscription>` needs. See the [crate-level
 /// docs](crate) for the full example and generated shape.
+///
+/// The type this attribute is applied to must implement `Clone` — see the
+/// [crate-level docs](crate#clone-requirement) for why.
 #[proc_macro_attribute]
 pub fn resolver(attr: TokenStream, item: TokenStream) -> TokenStream {
     resolver::resolver_impl(attr, item)

--- a/armature-graphql-macros/src/lib.rs
+++ b/armature-graphql-macros/src/lib.rs
@@ -1,0 +1,71 @@
+//! NestJS-style decorator macros for `armature-graphql` resolvers.
+//!
+//! `async-graphql`'s own `#[Object]` / `#[Subscription]` macros operate on a
+//! whole `impl` block: every method in the block becomes a field on that one
+//! GraphQL type. That means a single domain (e.g. "users") that needs a
+//! query, a mutation, *and* a subscription has to be split into three
+//! separate structs and three separate `impl` blocks by hand.
+//!
+//! This crate adds one macro, [`resolver`], that lets those three concerns
+//! live together in a single `impl` block — the way a NestJS `@Resolver()`
+//! class mixes `@Query()`, `@Mutation()`, and `@Subscription()` methods —
+//! and splits them apart at compile time into the separate types
+//! `async-graphql` needs, each driven by `async-graphql`'s real `#[Object]`
+//! / `#[Subscription]` macros under the hood. Argument extraction, output
+//! typing, descriptions, and error handling are therefore all
+//! `async-graphql`'s own, unmodified behavior — this crate only rearranges
+//! *which* methods go into *which* generated `impl` block.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use armature_graphql_macros::resolver;
+//!
+//! #[derive(Clone, Default)]
+//! struct UserResolver;
+//!
+//! #[resolver]
+//! impl UserResolver {
+//!     #[query]
+//!     async fn user(&self, id: async_graphql::ID) -> async_graphql::Result<User> {
+//!         // ...
+//!     }
+//!
+//!     #[mutation]
+//!     async fn create_user(&self, input: CreateUserInput) -> async_graphql::Result<User> {
+//!         // ...
+//!     }
+//!
+//!     #[subscription]
+//!     async fn user_created(&self) -> impl async_graphql::futures_util::Stream<Item = User> {
+//!         // ...
+//!     }
+//! }
+//! ```
+//!
+//! expands (roughly) to three wrapper types — `UserResolverQuery`,
+//! `UserResolverMutation`, `UserResolverSubscription` — each a
+//! `#[derive(Clone)] struct Wrapper(pub UserResolver);` that `Deref`s to
+//! `UserResolver` (so fields on the original type are still reachable from
+//! `self` inside the moved methods) and carries the matching real
+//! `async-graphql` macro. Compose them into your schema roots with
+//! [`async_graphql::MergedObject`]/[`async_graphql::MergedSubscription`]
+//! alongside other resolvers, exactly as you would with hand-written
+//! `#[Object]`/`#[Subscription]` types.
+//!
+//! Untagged methods in the `impl` block (plain helpers, no `#[query]`
+//! /`#[mutation]`/`#[subscription]`) are left in place on the original type
+//! and are not exposed as GraphQL fields.
+
+mod resolver;
+
+use proc_macro::TokenStream;
+
+/// Split an `impl` block's `#[query]`/`#[mutation]`/`#[subscription]`-tagged
+/// methods into the separate `async-graphql`-driven types a
+/// `Schema<Query, Mutation, Subscription>` needs. See the [crate-level
+/// docs](crate) for the full example and generated shape.
+#[proc_macro_attribute]
+pub fn resolver(attr: TokenStream, item: TokenStream) -> TokenStream {
+    resolver::resolver_impl(attr, item)
+}

--- a/armature-graphql-macros/src/resolver.rs
+++ b/armature-graphql-macros/src/resolver.rs
@@ -1,0 +1,382 @@
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{Error, Ident, ImplItem, ImplItemFn, ItemImpl, Type};
+
+/// Which generated GraphQL root a tagged method belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    Query,
+    Mutation,
+    Subscription,
+}
+
+impl Kind {
+    fn marker(self) -> &'static str {
+        match self {
+            Kind::Query => "query",
+            Kind::Mutation => "mutation",
+            Kind::Subscription => "subscription",
+        }
+    }
+
+    fn type_suffix(self) -> &'static str {
+        match self {
+            Kind::Query => "Query",
+            Kind::Mutation => "Mutation",
+            Kind::Subscription => "Subscription",
+        }
+    }
+
+    fn async_graphql_macro(self) -> proc_macro2::TokenStream {
+        match self {
+            Kind::Query | Kind::Mutation => quote! { ::async_graphql::Object },
+            Kind::Subscription => quote! { ::async_graphql::Subscription },
+        }
+    }
+}
+
+const ALL_KINDS: [Kind; 3] = [Kind::Query, Kind::Mutation, Kind::Subscription];
+
+/// Find the `#[query]`/`#[mutation]`/`#[subscription]` marker on a method,
+/// erroring if more than one is present. Returns `None` for methods without
+/// any of the three markers — those are left untouched on the original
+/// type.
+fn find_marker(method: &ImplItemFn) -> syn::Result<Option<Kind>> {
+    let mut found = None;
+
+    for attr in &method.attrs {
+        let Some(ident) = attr.path().get_ident() else {
+            continue;
+        };
+        let kind = match ident.to_string().as_str() {
+            "query" => Kind::Query,
+            "mutation" => Kind::Mutation,
+            "subscription" => Kind::Subscription,
+            _ => continue,
+        };
+
+        if !matches!(attr.meta, syn::Meta::Path(_)) {
+            return Err(Error::new_spanned(
+                attr,
+                format!(
+                    "#[{}] takes no arguments; use `async-graphql`'s own \
+                     #[graphql(...)] attribute on the method or its \
+                     parameters for field-level options",
+                    kind.marker()
+                ),
+            ));
+        }
+
+        if let Some(existing) = found {
+            let existing: Kind = existing;
+            return Err(Error::new_spanned(
+                attr,
+                format!(
+                    "method is already tagged #[{}]; a resolver method can \
+                     only be one of #[query], #[mutation], or #[subscription]",
+                    existing.marker()
+                ),
+            ));
+        }
+
+        found = Some(kind);
+    }
+
+    Ok(found)
+}
+
+fn strip_markers(method: &mut ImplItemFn) {
+    method.attrs.retain(|attr| match attr.path().get_ident() {
+        Some(ident) => !matches!(
+            ident.to_string().as_str(),
+            "query" | "mutation" | "subscription"
+        ),
+        None => true,
+    });
+}
+
+/// Extract the plain, non-generic type name an `impl` block is for (e.g.
+/// `Foo` out of `impl Foo { ... }`), rejecting the generic/qualified-path
+/// shapes this macro doesn't support yet.
+fn self_type_ident(self_ty: &Type) -> syn::Result<&Ident> {
+    let Type::Path(type_path) = self_ty else {
+        return Err(Error::new_spanned(
+            self_ty,
+            "#[resolver] only supports a plain `impl TypeName { ... }` block",
+        ));
+    };
+    if type_path.qself.is_some() {
+        return Err(Error::new_spanned(
+            self_ty,
+            "#[resolver] does not support qualified-path `impl` blocks",
+        ));
+    }
+    let segment = type_path.path.segments.last().ok_or_else(|| {
+        Error::new_spanned(self_ty, "#[resolver] requires a named type to implement")
+    })?;
+    if !segment.arguments.is_empty() {
+        return Err(Error::new_spanned(
+            self_ty,
+            "#[resolver] does not support generic types yet; implement each \
+             concrete instantiation separately",
+        ));
+    }
+    Ok(&segment.ident)
+}
+
+pub fn resolver_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
+    match resolver_impl2(attr.into(), item.into()) {
+        Ok(tokens) => tokens.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+fn resolver_impl2(
+    attr: proc_macro2::TokenStream,
+    item: proc_macro2::TokenStream,
+) -> syn::Result<proc_macro2::TokenStream> {
+    if !attr.is_empty() {
+        return Err(Error::new_spanned(attr, "#[resolver] takes no arguments"));
+    }
+
+    let input: ItemImpl = syn::parse2(item)?;
+
+    if let Some((_, path, _)) = &input.trait_ {
+        return Err(Error::new_spanned(
+            path,
+            "#[resolver] must be applied to an inherent `impl TypeName { ... }` \
+             block, not a trait impl",
+        ));
+    }
+
+    if !input.generics.params.is_empty() {
+        return Err(Error::new_spanned(
+            &input.generics,
+            "#[resolver] does not support generic `impl` blocks yet",
+        ));
+    }
+
+    let self_ty = &input.self_ty;
+    let struct_name = self_type_ident(self_ty)?.clone();
+
+    let mut buckets: [Vec<ImplItemFn>; 3] = [Vec::new(), Vec::new(), Vec::new()];
+    let mut remaining_items = Vec::new();
+
+    for item in input.items {
+        let ImplItem::Fn(mut method) = item else {
+            remaining_items.push(item);
+            continue;
+        };
+
+        let Some(kind) = find_marker(&method)? else {
+            remaining_items.push(ImplItem::Fn(method));
+            continue;
+        };
+
+        strip_markers(&mut method);
+        buckets[kind as usize].push(method);
+    }
+
+    let attrs = &input.attrs;
+    let unsafety = &input.unsafety;
+
+    let mut generated = Vec::new();
+
+    for kind in ALL_KINDS {
+        let methods = &buckets[kind as usize];
+        if methods.is_empty() {
+            continue;
+        }
+
+        let wrapper_name = format_ident!("{}{}", struct_name, kind.type_suffix());
+        let macro_path = kind.async_graphql_macro();
+
+        generated.push(quote! {
+            #[derive(Clone)]
+            #[doc(hidden)]
+            pub struct #wrapper_name(pub #struct_name);
+
+            impl ::std::ops::Deref for #wrapper_name {
+                type Target = #struct_name;
+
+                fn deref(&self) -> &Self::Target {
+                    &self.0
+                }
+            }
+
+            impl ::std::convert::From<#struct_name> for #wrapper_name {
+                fn from(value: #struct_name) -> Self {
+                    Self(value)
+                }
+            }
+
+            #[#macro_path]
+            impl #wrapper_name {
+                #(#methods)*
+            }
+        });
+    }
+
+    let expanded = quote! {
+        #(#attrs)*
+        #unsafety impl #self_ty {
+            #(#remaining_items)*
+        }
+
+        #(#generated)*
+    };
+
+    Ok(expanded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_quote;
+
+    #[test]
+    fn find_marker_recognizes_each_kind() {
+        let query: ImplItemFn = parse_quote! {
+            #[query]
+            async fn f(&self) -> i32 { 1 }
+        };
+        assert!(matches!(find_marker(&query).unwrap(), Some(Kind::Query)));
+
+        let mutation: ImplItemFn = parse_quote! {
+            #[mutation]
+            async fn f(&self) -> i32 { 1 }
+        };
+        assert!(matches!(
+            find_marker(&mutation).unwrap(),
+            Some(Kind::Mutation)
+        ));
+
+        let subscription: ImplItemFn = parse_quote! {
+            #[subscription]
+            async fn f(&self) -> i32 { 1 }
+        };
+        assert!(matches!(
+            find_marker(&subscription).unwrap(),
+            Some(Kind::Subscription)
+        ));
+    }
+
+    #[test]
+    fn find_marker_returns_none_for_untagged_methods() {
+        let plain: ImplItemFn = parse_quote! {
+            fn helper(&self) -> i32 { 1 }
+        };
+        assert!(find_marker(&plain).unwrap().is_none());
+
+        // Unrelated attributes (e.g. async-graphql's own field options) are
+        // ignored, not mistaken for a marker.
+        let with_graphql_attr: ImplItemFn = parse_quote! {
+            #[graphql(name = "foo")]
+            async fn f(&self) -> i32 { 1 }
+        };
+        assert!(find_marker(&with_graphql_attr).unwrap().is_none());
+    }
+
+    #[test]
+    fn find_marker_rejects_more_than_one_tag() {
+        let method: ImplItemFn = parse_quote! {
+            #[query]
+            #[mutation]
+            async fn f(&self) -> i32 { 1 }
+        };
+        let err = find_marker(&method).unwrap_err();
+        assert!(err.to_string().contains("already tagged"));
+    }
+
+    #[test]
+    fn find_marker_rejects_arguments_on_the_marker() {
+        let method: ImplItemFn = parse_quote! {
+            #[query(name = "foo")]
+            async fn f(&self) -> i32 { 1 }
+        };
+        let err = find_marker(&method).unwrap_err();
+        assert!(err.to_string().contains("takes no arguments"));
+    }
+
+    #[test]
+    fn strip_markers_removes_only_the_marker_attribute() {
+        let mut method: ImplItemFn = parse_quote! {
+            #[query]
+            #[graphql(name = "foo")]
+            async fn f(&self) -> i32 { 1 }
+        };
+        strip_markers(&mut method);
+        assert_eq!(method.attrs.len(), 1);
+        assert_eq!(
+            method.attrs[0].path().get_ident().unwrap().to_string(),
+            "graphql"
+        );
+    }
+
+    #[test]
+    fn self_type_ident_accepts_a_plain_named_type() {
+        let ty: Type = parse_quote! { Foo };
+        assert_eq!(self_type_ident(&ty).unwrap().to_string(), "Foo");
+    }
+
+    #[test]
+    fn self_type_ident_rejects_generics() {
+        let ty: Type = parse_quote! { Foo<T> };
+        assert!(self_type_ident(&ty).is_err());
+    }
+
+    #[test]
+    fn self_type_ident_rejects_non_path_types() {
+        let ty: Type = parse_quote! { (Foo, Bar) };
+        assert!(self_type_ident(&ty).is_err());
+    }
+
+    #[test]
+    fn resolver_impl_rejects_trait_impls() {
+        let attr = proc_macro2::TokenStream::new();
+        let item = quote! {
+            impl SomeTrait for Foo {}
+        };
+        let err = resolver_impl2(attr, item).unwrap_err();
+        assert!(err.to_string().contains("inherent"));
+    }
+
+    #[test]
+    fn resolver_impl_rejects_generic_impls() {
+        let attr = proc_macro2::TokenStream::new();
+        let item = quote! {
+            impl<T> Foo<T> {}
+        };
+        let err = resolver_impl2(attr, item).unwrap_err();
+        assert!(err.to_string().contains("generic"));
+    }
+
+    #[test]
+    fn resolver_impl_rejects_attribute_arguments() {
+        let attr = quote! { some_arg };
+        let item = quote! {
+            impl Foo {}
+        };
+        let err = resolver_impl2(attr, item).unwrap_err();
+        assert!(err.to_string().contains("takes no arguments"));
+    }
+
+    #[test]
+    fn resolver_impl_leaves_untagged_methods_on_the_original_type_only() {
+        let attr = proc_macro2::TokenStream::new();
+        let item = quote! {
+            impl Foo {
+                #[query]
+                async fn a(&self) -> i32 { 1 }
+
+                fn helper(&self) -> i32 { 2 }
+            }
+        };
+        let out = resolver_impl2(attr, item).unwrap().to_string();
+        assert!(out.contains("FooQuery"));
+        assert!(!out.contains("FooMutation"));
+        assert!(!out.contains("FooSubscription"));
+        // The helper stays in the original `impl Foo` block only.
+        assert_eq!(out.matches("helper").count(), 1);
+    }
+}

--- a/armature-graphql-macros/src/resolver.rs
+++ b/armature-graphql-macros/src/resolver.rs
@@ -3,6 +3,14 @@ use quote::{format_ident, quote};
 use syn::{Error, Ident, ImplItem, ImplItemFn, ItemImpl, Type};
 
 /// Which generated GraphQL root a tagged method belongs to.
+///
+/// The marker names below (`"query"`/`"mutation"`/`"subscription"`, see
+/// [`Kind::marker`] and [`find_marker`]) are also independently recognized,
+/// by source-text parsing rather than macro expansion, by
+/// `armature-graphql`'s static SDL analyzer (`resolver_marker()` in
+/// `armature-graphql/src/sdl_static.rs`). There is no compiler-enforced link
+/// between the two lists — if a marker name here is ever renamed, or a new
+/// one is added, that function needs the matching update too.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Kind {
     Query,
@@ -41,6 +49,9 @@ const ALL_KINDS: [Kind; 3] = [Kind::Query, Kind::Mutation, Kind::Subscription];
 /// erroring if more than one is present. Returns `None` for methods without
 /// any of the three markers — those are left untouched on the original
 /// type.
+///
+/// See the note on [`Kind`] about `armature-graphql`'s `sdl_static.rs`
+/// independently recognizing these same marker strings.
 fn find_marker(method: &ImplItemFn) -> syn::Result<Option<Kind>> {
     let mut found = None;
 

--- a/armature-graphql-macros/tests/trybuild.rs
+++ b/armature-graphql-macros/tests/trybuild.rs
@@ -1,0 +1,14 @@
+//! Compile-pass coverage: `#[resolver]` must compile when used as documented
+//! on a realistic query + mutation + subscription impl block, composed via
+//! `MergedObject`/`MergedSubscription`.
+//!
+//! Deliberately no compile-fail cases here (fragile, rustc-version-dependent
+//! stderr matching) — the unit tests in `src/resolver.rs` already give
+//! robust, version-independent coverage of the rejection paths by asserting
+//! on `syn::Error` message content directly.
+
+#[test]
+fn resolver_compiles() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/resolver_pass.rs");
+}

--- a/armature-graphql-macros/tests/ui/resolver_pass.rs
+++ b/armature-graphql-macros/tests/ui/resolver_pass.rs
@@ -1,0 +1,58 @@
+use armature_graphql_macros::resolver;
+use async_graphql::{futures_util::stream::Stream, SimpleObject};
+
+#[derive(Clone, SimpleObject)]
+struct User {
+    id: String,
+    name: String,
+}
+
+#[derive(Clone, Default)]
+pub struct UserResolver;
+
+#[resolver]
+impl UserResolver {
+    #[query]
+    async fn user(&self, id: String) -> async_graphql::Result<User> {
+        Ok(User {
+            id,
+            name: "ada".to_string(),
+        })
+    }
+
+    #[mutation]
+    async fn create_user(&self, name: String) -> async_graphql::Result<User> {
+        Ok(User {
+            id: "1".to_string(),
+            name,
+        })
+    }
+
+    #[subscription]
+    async fn user_created(&self) -> impl Stream<Item = User> {
+        async_graphql::futures_util::stream::once(async {
+            User {
+                id: "1".to_string(),
+                name: "ada".to_string(),
+            }
+        })
+    }
+}
+
+#[derive(async_graphql::MergedObject)]
+struct RootQuery(UserResolverQuery);
+
+#[derive(async_graphql::MergedObject)]
+struct RootMutation(UserResolverMutation);
+
+#[derive(async_graphql::MergedSubscription)]
+struct RootSubscription(UserResolverSubscription);
+
+fn main() {
+    let resolver = UserResolver;
+    let query = RootQuery(resolver.clone().into());
+    let mutation = RootMutation(resolver.clone().into());
+    let subscription = RootSubscription(resolver.into());
+
+    let _schema = async_graphql::Schema::build(query, mutation, subscription).finish();
+}

--- a/armature-graphql/Cargo.toml
+++ b/armature-graphql/Cargo.toml
@@ -14,9 +14,9 @@ categories = ["web-programming", "api-bindings"]
 [dependencies]
 armature-core = { path = "../armature-core", version = "0" }
 armature-log = { path = "../armature-log", version = "0" }
+armature-graphql-macros = { path = "../armature-graphql-macros", version = "0" }
 async-graphql = { version = "7.2.1", features = ["apollo_tracing"] }
-async-graphql-axum = "7.2.1"
-tokio = { version = "1.52", features = ["rt", "rt-multi-thread", "macros", "sync", "time"] }
+tokio = { version = "1.52", features = ["rt", "rt-multi-thread", "macros", "sync", "time", "io-util"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 async-trait = "0.1"
@@ -26,6 +26,7 @@ futures = { version = "0.3", optional = true }
 clap = { version = "4.6", features = ["derive"], optional = true }
 syn = { version = "2.0", features = ["full", "extra-traits"], optional = true }
 proc-macro2 = { version = "1.0", optional = true }
+tokio-tungstenite = { version = "0.29", default-features = false, optional = true }
 
 [features]
 default = []
@@ -37,6 +38,11 @@ federation = ["reqwest", "futures"]
 # external-subcommand mechanism (`armature graphql-sdl ...`) once installed
 # on $PATH.
 sdl-export = ["dep:syn", "dep:proc-macro2", "dep:clap"]
+# GraphQL subscriptions transported over WebSocket (`graphql-transport-ws` /
+# `graphql-ws`). Transport-agnostic: drives any `tokio_tungstenite::WebSocketStream`
+# handed to it after the caller (e.g. armature-core) has already completed the
+# HTTP Upgrade handshake.
+websocket = ["dep:tokio-tungstenite"]
 
 [[bin]]
 name = "armature-graphql-sdl"

--- a/armature-graphql/src/decorators.rs
+++ b/armature-graphql/src/decorators.rs
@@ -55,37 +55,6 @@ pub mod context {
     pub use async_graphql::Context;
 }
 
-// Macro for defining resolvers with NestJS-like syntax
-#[macro_export]
-macro_rules! resolver {
-    (
-        $(#[$meta:meta])*
-        $vis:vis struct $name:ident {
-            $($field:ident: $field_ty:ty),* $(,)?
-        }
-
-        impl $impl_name:ident {
-            $(
-                $(#[$method_meta:meta])*
-                async fn $method:ident(&self $(, $arg:ident: $arg_ty:ty)*) -> $ret:ty $body:block
-            )*
-        }
-    ) => {
-        $(#[$meta])*
-        $vis struct $name {
-            $($field: $field_ty),*
-        }
-
-        #[async_graphql::Object]
-        impl $impl_name {
-            $(
-                $(#[$method_meta])*
-                async fn $method(&self $(, $arg: $arg_ty)*) -> $ret $body
-            )*
-        }
-    };
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/armature-graphql/src/federation.rs
+++ b/armature-graphql/src/federation.rs
@@ -34,8 +34,8 @@
 //!
 //! `SubgraphSchemaBuilder` only builds an `async-graphql` [`Schema`] with
 //! federation directives enabled — it does not run an HTTP server. Serve the
-//! resulting schema yourself (e.g. with `async-graphql-axum`, which this
-//! crate already depends on) the same way you would serve any other
+//! resulting schema yourself (e.g. with `async-graphql-axum`, added as a
+//! dependency in your own binary) the same way you would serve any other
 //! `async-graphql` schema.
 //!
 //! ```rust,ignore
@@ -72,8 +72,9 @@
 //!     .build()?;
 //!
 //! // `schema.schema()` returns the underlying `async_graphql::Schema`; wire
-//! // it into your own HTTP router (e.g. `async_graphql_axum::GraphQL`) to
-//! // actually serve it. This crate does not include a server/runtime.
+//! // it into your own HTTP router (e.g. `async_graphql_axum::GraphQL`, added
+//! // as a dependency in your own binary) to actually serve it. This crate
+//! // does not include a server/runtime.
 //! ```
 //!
 //! ## Example: Querying subgraphs from a gateway
@@ -792,10 +793,17 @@ pub use gateway::*;
 // Federation Directives
 // =============================================================================
 
-/// Marker trait for entities that can be resolved across subgraph boundaries
+/// Optional, purely conventional marker trait for entities that can be
+/// resolved across subgraph boundaries.
 ///
-/// Entities are the core building blocks of Apollo Federation.
-/// They can be referenced and extended by other subgraphs.
+/// Implementing this trait documents intent, but it is not currently
+/// consumed anywhere by this crate's own code: no macro generates
+/// implementations of it, and no gateway or entity-resolution logic in this
+/// module calls `typename()` or `resolve()` on it. The actually-used
+/// mechanism for entity resolution is async-graphql's native
+/// `#[graphql(entity)]` attribute applied directly to a method on an
+/// `#[Object]`/`#[ComplexObject]` impl — see this module's top-level doc
+/// example (`find_by_id`) for how that is wired up in practice.
 pub trait FederatedEntity: Sized {
     /// The typename as it appears in the schema
     fn typename() -> &'static str;
@@ -924,6 +932,15 @@ pub fn compose_supergraph(
 // =============================================================================
 
 /// Information about a federated service
+///
+/// Not currently populated or used by [`FederationGateway`]/
+/// [`FederationGatewayBuilder`] (behind the `federation` feature) or
+/// anywhere else in this crate — nothing ever constructs, updates, or
+/// returns a `ServiceInfo`. If constructed via [`ServiceInfo::new`],
+/// `healthy` and `sdl` will always be their default values (`false` and
+/// `None`), since there is no other constructor or mutator. This is a
+/// disconnected DTO today: a future extension point, not live
+/// functionality.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServiceInfo {
     /// The service name

--- a/armature-graphql/src/lib.rs
+++ b/armature-graphql/src/lib.rs
@@ -61,9 +61,6 @@ impl<Query, Mutation, Subscription> Clone for GraphQLSchema<Query, Mutation, Sub
     }
 }
 
-// Provider is automatically implemented via blanket impl
-// when Query, Mutation, Subscription all satisfy Send + Sync + 'static
-
 /// GraphQL request handling
 pub struct GraphQLRequest {
     pub query: String,
@@ -331,5 +328,18 @@ mod tests {
         let json = response.to_json().unwrap();
         assert!(json.contains("hello"));
         assert!(json.contains("world"));
+    }
+
+    #[test]
+    fn test_graphql_response_error_serialization() {
+        let response = GraphQLResponse::error("something went wrong".to_string());
+
+        let json = response.to_json().unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert!(value["data"].is_null());
+        assert!(json.contains("\"data\":null"));
+        assert!(value["errors"].is_array());
+        assert_eq!(value["errors"][0], "something went wrong");
     }
 }

--- a/armature-graphql/src/lib.rs
+++ b/armature-graphql/src/lib.rs
@@ -8,7 +8,10 @@ pub mod schema_builder;
 pub mod schema_docs;
 #[cfg(feature = "sdl-export")]
 pub mod sdl_static;
+#[cfg(feature = "websocket")]
+pub mod websocket;
 
+pub use armature_graphql_macros::resolver;
 pub use async_graphql;
 pub use async_graphql::{
     Context, EmptyMutation, EmptySubscription, Enum, Error, ID, InputObject, MergedObject,
@@ -20,6 +23,8 @@ pub use decorators::*;
 pub use resolver::*;
 pub use schema_builder::*;
 pub use schema_docs::*;
+#[cfg(feature = "websocket")]
+pub use websocket::{ALL_WEBSOCKET_PROTOCOLS, Protocols, select_protocol, serve_graphql_websocket};
 
 use armature_core::Error as ArmatureError;
 use armature_log::info;

--- a/armature-graphql/src/resolver.rs
+++ b/armature-graphql/src/resolver.rs
@@ -8,21 +8,41 @@ pub trait Resolver: Send + Sync {
     fn as_any(&self) -> &dyn Any;
 }
 
-/// Trait for query resolvers
+/// Optional marker trait for manually categorizing a type as a query resolver.
+///
+/// This is a purely conventional, opt-in trait for callers who want to
+/// explicitly tag their resolver types. Nothing in this crate — including
+/// the `#[resolver]` macro (`armature-graphql-macros`) — generates
+/// implementations of it or consumes it automatically; implementing it has
+/// no effect beyond documenting intent.
 pub trait QueryResolver: Resolver {
     fn type_name() -> &'static str
     where
         Self: Sized;
 }
 
-/// Trait for mutation resolvers
+/// Optional marker trait for manually categorizing a type as a mutation
+/// resolver.
+///
+/// This is a purely conventional, opt-in trait for callers who want to
+/// explicitly tag their resolver types. Nothing in this crate — including
+/// the `#[resolver]` macro (`armature-graphql-macros`) — generates
+/// implementations of it or consumes it automatically; implementing it has
+/// no effect beyond documenting intent.
 pub trait MutationResolver: Resolver {
     fn type_name() -> &'static str
     where
         Self: Sized;
 }
 
-/// Trait for subscription resolvers
+/// Optional marker trait for manually categorizing a type as a subscription
+/// resolver.
+///
+/// This is a purely conventional, opt-in trait for callers who want to
+/// explicitly tag their resolver types. Nothing in this crate — including
+/// the `#[resolver]` macro (`armature-graphql-macros`) — generates
+/// implementations of it or consumes it automatically; implementing it has
+/// no effect beyond documenting intent.
 pub trait SubscriptionResolver: Resolver {
     fn type_name() -> &'static str
     where
@@ -38,5 +58,75 @@ pub trait ContextExt {
 impl<'a> ContextExt for Context<'a> {
     fn get_service<T: Send + Sync + 'static>(&self) -> Result<&T> {
         self.data::<T>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_graphql::{EmptyMutation, EmptySubscription, Schema};
+
+    /// A service that is registered in the schema's context data, used to
+    /// exercise the found (`Ok`) path of `ContextExt::get_service`.
+    struct GreeterService {
+        greeting: String,
+    }
+
+    /// A service type that is deliberately never registered, used to
+    /// exercise the not-found (`Err`) path of `ContextExt::get_service`.
+    struct UnregisteredService;
+
+    struct TestQuery;
+
+    #[async_graphql::Object]
+    impl TestQuery {
+        /// Resolves via a service that *is* present in the schema data.
+        async fn greeting(&self, ctx: &Context<'_>) -> Result<String> {
+            let service = ctx.get_service::<GreeterService>()?;
+            Ok(service.greeting.clone())
+        }
+
+        /// Attempts to resolve a service that was never registered; expected
+        /// to surface as a GraphQL error rather than panic.
+        async fn missing(&self, ctx: &Context<'_>) -> Result<String> {
+            let _service = ctx.get_service::<UnregisteredService>()?;
+            Ok("unreachable".to_string())
+        }
+    }
+
+    fn build_schema() -> Schema<TestQuery, EmptyMutation, EmptySubscription> {
+        Schema::build(TestQuery, EmptyMutation, EmptySubscription)
+            .data(GreeterService {
+                greeting: "hello from DI".to_string(),
+            })
+            .finish()
+    }
+
+    #[test]
+    fn test_context_ext_get_service_found() {
+        let schema = build_schema();
+
+        let response = tokio_test::block_on(schema.execute("{ greeting }"));
+
+        assert!(
+            response.errors.is_empty(),
+            "expected no errors, got: {:?}",
+            response.errors
+        );
+
+        let data = response.data.into_json().unwrap();
+        assert_eq!(data["greeting"], "hello from DI");
+    }
+
+    #[test]
+    fn test_context_ext_get_service_not_found() {
+        let schema = build_schema();
+
+        let response = tokio_test::block_on(schema.execute("{ missing }"));
+
+        assert!(
+            !response.errors.is_empty(),
+            "expected an error for an unregistered service, got none"
+        );
     }
 }

--- a/armature-graphql/src/schema_builder.rs
+++ b/armature-graphql/src/schema_builder.rs
@@ -104,28 +104,6 @@ impl EmptyQuery {
     }
 }
 
-/// Helper to create an empty mutation root
-#[derive(Default)]
-pub struct EmptyMutation;
-
-#[async_graphql::Object]
-impl EmptyMutation {
-    async fn _empty(&self) -> &str {
-        ""
-    }
-}
-
-/// Helper to create an empty subscription root
-#[derive(Default)]
-pub struct EmptySubscription;
-
-#[async_graphql::Subscription]
-impl EmptySubscription {
-    async fn _empty(&self) -> impl async_graphql::futures_util::Stream<Item = &str> {
-        async_graphql::futures_util::stream::empty()
-    }
-}
-
 /// Macro to merge multiple resolver objects into a single root
 #[macro_export]
 macro_rules! merge_resolvers {
@@ -159,8 +137,8 @@ mod tests {
     fn test_schema_builder() {
         let _schema = ProgrammaticSchemaBuilder::new()
             .query(TestQuery)
-            .mutation(EmptyMutation)
-            .subscription(EmptySubscription)
+            .mutation(async_graphql::EmptyMutation)
+            .subscription(async_graphql::EmptySubscription)
             .build();
     }
 
@@ -196,8 +174,8 @@ mod tests {
 
         let schema = ProgrammaticSchemaBuilder::new()
             .query(merged)
-            .mutation(EmptyMutation)
-            .subscription(EmptySubscription)
+            .mutation(async_graphql::EmptyMutation)
+            .subscription(async_graphql::EmptySubscription)
             .build();
 
         let response = tokio_test::block_on(schema.execute("{ alpha beta }"));

--- a/armature-graphql/src/sdl_static.rs
+++ b/armature-graphql/src/sdl_static.rs
@@ -446,6 +446,9 @@ fn collect_interface_fields(attr: &syn::Attribute, fields: &mut Vec<Field>) {
         if meta.path.is_ident("field") {
             let mut name = None;
             let mut type_str = None;
+            let mut desc = None;
+            let mut deprecation = None;
+            let mut args = Vec::new();
             meta.parse_nested_meta(|inner| {
                 if inner.path.is_ident("name") {
                     let value = inner.value()?;
@@ -455,6 +458,54 @@ fn collect_interface_fields(attr: &syn::Attribute, fields: &mut Vec<Field>) {
                     let value = inner.value()?;
                     let lit: syn::LitStr = value.parse()?;
                     type_str = Some(lit.value());
+                } else if inner.path.is_ident("desc") {
+                    let value = inner.value()?;
+                    let lit: syn::LitStr = value.parse()?;
+                    desc = Some(lit.value());
+                } else if inner.path.is_ident("deprecation") {
+                    if inner.input.peek(syn::Token![=]) {
+                        let value = inner.value()?;
+                        let lit: syn::LitStr = value.parse()?;
+                        deprecation = Some(Deprecation {
+                            reason: Some(lit.value()),
+                        });
+                    } else {
+                        deprecation = Some(Deprecation { reason: None });
+                    }
+                } else if inner.path.is_ident("arg") {
+                    let mut arg_name = None;
+                    let mut arg_type = None;
+                    let mut arg_default = None;
+                    inner.parse_nested_meta(|arg_meta| {
+                        if arg_meta.path.is_ident("name") {
+                            let value = arg_meta.value()?;
+                            let lit: syn::LitStr = value.parse()?;
+                            arg_name = Some(lit.value());
+                        } else if arg_meta.path.is_ident("type") {
+                            let value = arg_meta.value()?;
+                            let lit: syn::LitStr = value.parse()?;
+                            arg_type = Some(lit.value());
+                        } else if arg_meta.path.is_ident("default") {
+                            if arg_meta.input.peek(syn::Token![=]) {
+                                let value = arg_meta.value()?;
+                                if let Ok(lit) = value.parse::<syn::Lit>() {
+                                    arg_default = Some(literal_to_sdl(&lit));
+                                }
+                            } else {
+                                arg_default = Some("null".to_string());
+                            }
+                        } else {
+                            let _ = arg_meta.value().and_then(|v| v.parse::<syn::Lit>());
+                        }
+                        Ok(())
+                    })?;
+                    if let (Some(arg_name), Some(arg_type)) = (arg_name, arg_type) {
+                        args.push(Arg {
+                            name: arg_name,
+                            type_str: arg_type,
+                            default: arg_default,
+                        });
+                    }
                 } else {
                     let _ = inner.value().and_then(|v| v.parse::<syn::Lit>());
                 }
@@ -463,10 +514,10 @@ fn collect_interface_fields(attr: &syn::Attribute, fields: &mut Vec<Field>) {
             if let (Some(name), Some(type_str)) = (name, type_str) {
                 fields.push(Field {
                     name: to_camel_case(&name),
-                    description: None,
-                    args: Vec::new(),
+                    description: desc,
+                    args,
                     type_str,
-                    deprecated: None,
+                    deprecated: deprecation,
                 });
             }
         }
@@ -863,13 +914,36 @@ mod tests {
                     vec![]
                 }
 
+                async fn recent(&self, #[graphql(default = 10)] limit: i32) -> Vec<User> {
+                    vec![]
+                }
+
                 fn helper(&self) {}
             }
             "#,
         );
         assert!(sdl.contains("user(id: ID!): User\n"));
         assert!(sdl.contains("users(limit: Int): [User!]!\n"));
+        assert!(sdl.contains("recent(limit: Int! = 10): [User!]!\n"));
         assert!(!sdl.contains("helper"));
+    }
+
+    #[test]
+    fn resolver_impl_with_no_marked_methods_produces_no_root_type() {
+        let sdl = render(
+            r#"
+            struct UserResolver;
+
+            #[resolver]
+            impl UserResolver {
+                fn helper(&self) {}
+            }
+            "#,
+        );
+        assert!(!sdl.contains("type Query {"));
+        assert!(!sdl.contains("type Mutation {"));
+        assert!(!sdl.contains("type Subscription {"));
+        assert!(sdl.is_empty());
     }
 
     #[test]
@@ -1003,6 +1077,29 @@ mod tests {
         assert!(sdl.contains("ACTIVE"));
         assert!(sdl.contains("PENDING_REVIEW"));
         assert!(sdl.contains("ARCHIVED_LEGACY"));
+    }
+
+    #[test]
+    fn interface_fields_from_graphql_field_attr() {
+        let sdl = render(
+            r#"
+            #[derive(Interface)]
+            #[graphql(field(
+                name = "name",
+                type = "String",
+                desc = "The entity's name.",
+                deprecation = "use displayName instead",
+                arg(name = "uppercase", type = "bool")
+            ))]
+            enum Named {
+                UserNamed(User),
+                PostNamed(Post),
+            }
+            "#,
+        );
+        assert!(sdl.contains("interface Named {"));
+        assert!(sdl.contains("\"The entity's name.\" name(uppercase: bool): String"));
+        assert!(sdl.contains("@deprecated(reason: \"use displayName instead\")"));
     }
 
     #[test]

--- a/armature-graphql/src/sdl_static.rs
+++ b/armature-graphql/src/sdl_static.rs
@@ -11,6 +11,10 @@
 //! - `#[derive(Union)]` newtype-variant enums
 //! - `#[derive(Interface)]` enums with `#[graphql(field(name = "..", type = ".."))]`
 //! - `#[Scalar]` impl blocks
+//! - `armature_graphql_macros::resolver`'s `#[query]`/`#[mutation]`/
+//!   `#[subscription]`-tagged methods, folded into the conventional
+//!   "Query"/"Mutation"/"Subscription" root type entries (see
+//!   [`resolver_marker`])
 //!
 //! This is necessarily a subset of what the real macros support (they run
 //! as full proc-macros with type information this pass doesn't have) — the
@@ -216,8 +220,32 @@ impl SchemaBuilder {
         let is_subscription = has_attr_ident(&imp.attrs, "Subscription");
         let is_complex_object = has_attr_ident(&imp.attrs, "ComplexObject");
         let is_scalar = has_attr_ident(&imp.attrs, "Scalar");
+        // `armature_graphql_macros::resolver`: a single `impl` block whose
+        // methods are individually tagged `#[query]`/`#[mutation]`/
+        // `#[subscription]` and get split at compile time into separate
+        // `#[Object]`/`#[Subscription]` impls on synthesized wrapper types.
+        // Since those synthesized types don't exist in source text for this
+        // pass to see, route each tagged method's field straight into the
+        // conventional "Query"/"Mutation"/"Subscription" root type entries
+        // instead — matching how the generated wrapper types are meant to be
+        // composed via `#[derive(MergedObject)]`/`#[derive(MergedSubscription)]`.
+        let is_resolver = has_attr_ident(&imp.attrs, "resolver");
 
-        if !(is_object || is_subscription || is_complex_object || is_scalar) {
+        if !(is_object || is_subscription || is_complex_object || is_scalar || is_resolver) {
+            return;
+        }
+
+        if is_resolver {
+            for item in &imp.items {
+                let ImplItem::Fn(m) = item else { continue };
+                let Some(root_name) = resolver_marker(&m.attrs) else {
+                    continue;
+                };
+                let Some(field) = build_field(m) else {
+                    continue;
+                };
+                self.entry(TypeKind::Object, root_name).fields.push(field);
+            }
             return;
         }
 
@@ -232,52 +260,10 @@ impl SchemaBuilder {
 
         let def = self.entry(TypeKind::Object, &name);
         for item in &imp.items {
-            if let ImplItem::Fn(m) = item {
-                let attrs = graphql_attrs(&m.attrs);
-                if attrs.skip {
-                    continue;
-                }
-                let Some(ret_ty) = return_type(&m.sig.output) else {
-                    continue;
-                };
-                let field_name = attrs
-                    .name
-                    .clone()
-                    .unwrap_or_else(|| to_camel_case(&m.sig.ident.to_string()));
-
-                let mut args = Vec::new();
-                for input in &m.sig.inputs {
-                    let FnArg::Typed(pat_type) = input else {
-                        continue;
-                    };
-                    if type_mentions_context(&pat_type.ty) {
-                        continue;
-                    }
-                    let arg_attrs = graphql_attrs(&pat_type.attrs);
-                    if arg_attrs.skip {
-                        continue;
-                    }
-                    let Pat::Ident(pat_ident) = pat_type.pat.as_ref() else {
-                        continue;
-                    };
-                    let arg_name = arg_attrs
-                        .name
-                        .clone()
-                        .unwrap_or_else(|| to_camel_case(&pat_ident.ident.to_string()));
-                    args.push(Arg {
-                        name: arg_name,
-                        type_str: graphql_type(&pat_type.ty),
-                        default: arg_attrs.default,
-                    });
-                }
-
-                def.fields.push(Field {
-                    name: field_name,
-                    description: doc_string(&m.attrs),
-                    args,
-                    type_str: graphql_type(ret_ty),
-                    deprecated: attrs.deprecation,
-                });
+            if let ImplItem::Fn(m) = item
+                && let Some(field) = build_field(m)
+            {
+                def.fields.push(field);
             }
         }
     }
@@ -588,6 +574,65 @@ fn has_attr_ident(attrs: &[syn::Attribute], ident: &str) -> bool {
     attrs.iter().any(|a| a.path().is_ident(ident))
 }
 
+/// The conventional root type name a `#[resolver]`-tagged method's
+/// `#[query]`/`#[mutation]`/`#[subscription]` marker maps to.
+fn resolver_marker(attrs: &[syn::Attribute]) -> Option<&'static str> {
+    attrs.iter().find_map(|a| match a.path().get_ident() {
+        Some(ident) if ident == "query" => Some("Query"),
+        Some(ident) if ident == "mutation" => Some("Mutation"),
+        Some(ident) if ident == "subscription" => Some("Subscription"),
+        _ => None,
+    })
+}
+
+/// Build a [`Field`] from one `#[Object]`/`#[Subscription]`-style method,
+/// or `None` if it's `#[graphql(skip)]`-tagged or has no return type.
+fn build_field(m: &syn::ImplItemFn) -> Option<Field> {
+    let attrs = graphql_attrs(&m.attrs);
+    if attrs.skip {
+        return None;
+    }
+    let ret_ty = return_type(&m.sig.output)?;
+    let field_name = attrs
+        .name
+        .clone()
+        .unwrap_or_else(|| to_camel_case(&m.sig.ident.to_string()));
+
+    let mut args = Vec::new();
+    for input in &m.sig.inputs {
+        let FnArg::Typed(pat_type) = input else {
+            continue;
+        };
+        if type_mentions_context(&pat_type.ty) {
+            continue;
+        }
+        let arg_attrs = graphql_attrs(&pat_type.attrs);
+        if arg_attrs.skip {
+            continue;
+        }
+        let Pat::Ident(pat_ident) = pat_type.pat.as_ref() else {
+            continue;
+        };
+        let arg_name = arg_attrs
+            .name
+            .clone()
+            .unwrap_or_else(|| to_camel_case(&pat_ident.ident.to_string()));
+        args.push(Arg {
+            name: arg_name,
+            type_str: graphql_type(&pat_type.ty),
+            default: arg_attrs.default,
+        });
+    }
+
+    Some(Field {
+        name: field_name,
+        description: doc_string(&m.attrs),
+        args,
+        type_str: graphql_type(ret_ty),
+        deprecated: attrs.deprecation,
+    })
+}
+
 fn doc_string(attrs: &[syn::Attribute]) -> Option<String> {
     let mut lines = Vec::new();
     for attr in attrs {
@@ -825,6 +870,69 @@ mod tests {
         assert!(sdl.contains("user(id: ID!): User\n"));
         assert!(sdl.contains("users(limit: Int): [User!]!\n"));
         assert!(!sdl.contains("helper"));
+    }
+
+    #[test]
+    fn resolver_macro_methods_fold_into_the_conventional_root_types() {
+        let sdl = render(
+            r#"
+            struct UserResolver;
+
+            #[resolver]
+            impl UserResolver {
+                #[query]
+                async fn user(&self, id: ID) -> Option<User> {
+                    None
+                }
+
+                #[mutation]
+                async fn create_user(&self, name: String) -> User {
+                    unreachable!()
+                }
+
+                #[subscription]
+                async fn user_created(&self) -> impl Stream<Item = User> {
+                    unreachable!()
+                }
+
+                fn helper(&self) {}
+            }
+            "#,
+        );
+        assert!(sdl.contains("type Query {\n  user(id: ID!): User\n"));
+        assert!(sdl.contains("type Mutation {\n  createUser(name: String!): User!\n"));
+        assert!(sdl.contains("type Subscription {\n  userCreated:"));
+        assert!(!sdl.contains("helper"));
+    }
+
+    #[test]
+    fn resolver_macro_fields_merge_with_plain_object_impls() {
+        let sdl = render(
+            r#"
+            struct Query;
+
+            #[Object]
+            impl Query {
+                async fn ping(&self) -> String {
+                    "pong".to_string()
+                }
+            }
+
+            struct UserResolver;
+
+            #[resolver]
+            impl UserResolver {
+                #[query]
+                async fn user(&self, id: ID) -> Option<User> {
+                    None
+                }
+            }
+            "#,
+        );
+        assert!(sdl.contains("ping: String!"));
+        assert!(sdl.contains("user(id: ID!): User"));
+        // Both merge into a single "Query" type, not two separate ones.
+        assert_eq!(sdl.matches("type Query {").count(), 1);
     }
 
     #[test]

--- a/armature-graphql/src/websocket.rs
+++ b/armature-graphql/src/websocket.rs
@@ -13,8 +13,10 @@
 //!    request header via [`select_protocol`].
 //! 2. Completing the WebSocket upgrade and producing a
 //!    [`tokio_tungstenite::WebSocketStream`].
-//! 3. Calling [`serve_graphql_websocket`] with that stream and the built
-//!    [`async_graphql::Schema`].
+//! 3. Calling [`serve_graphql_websocket`] with that stream, the built
+//!    [`async_graphql::Schema`], and a [`WebSocketConfig`] describing the
+//!    connection's keep-alive timeout, subscription cap, and (optionally) a
+//!    `connection_init` authentication hook.
 //!
 //! Only text frames are treated as GraphQL-over-WebSocket protocol messages;
 //! binary frames are ignored, matching the text-only `graphql-ws` /
@@ -22,10 +24,16 @@
 //! left to `tokio-tungstenite`'s own automatic handling, consistent with
 //! [`armature_core::websocket::handle_websocket`].
 
+use std::collections::HashSet;
+use std::time::Duration;
+
 use armature_core::Error as ArmatureError;
+use armature_log::warn;
 use async_graphql::Executor;
+use async_graphql::futures_util::future::BoxFuture;
 use async_graphql::futures_util::{SinkExt, StreamExt};
 use async_graphql::http::{self, ClientMessage};
+use async_graphql::{Data, Result as GqlResult};
 use tokio_tungstenite::WebSocketStream;
 use tokio_tungstenite::tungstenite::Message as WsFrame;
 use tokio_tungstenite::tungstenite::protocol::CloseFrame;
@@ -56,19 +64,127 @@ pub fn select_protocol(header_value: Option<&str>) -> Result<Protocols, Armature
         })
 }
 
+/// A boxed `connection_init` validation/authentication callback.
+///
+/// Mirrors the closure shape accepted by
+/// [`async_graphql::http::WebSocket::on_connection_init`], boxed so it can be
+/// stored in [`WebSocketConfig`] without leaking a generic parameter into
+/// [`serve_graphql_websocket`]'s signature.
+pub type OnConnectionInit =
+    Box<dyn FnOnce(serde_json::Value) -> BoxFuture<'static, GqlResult<Data>> + Send>;
+
+/// Per-connection tuning knobs for [`serve_graphql_websocket`].
+///
+/// Construct with [`WebSocketConfig::default`] and override individual
+/// fields, or use the `with_*` builder methods.
+pub struct WebSocketConfig {
+    /// Disconnect the client if no message (including a keep-alive ping ack)
+    /// is seen within this duration. `None` disables the timeout entirely,
+    /// which is not recommended for internet-facing servers since an
+    /// unresponsive client with an open TCP connection would never be
+    /// dropped. Applies to both sub-protocols.
+    pub keepalive_timeout: Option<Duration>,
+
+    /// Reject `subscribe`/`start` messages once this many subscriptions are
+    /// open on this connection. `None` means unbounded, which is not
+    /// recommended for internet-facing servers: a single client could
+    /// otherwise open unbounded concurrent subscriptions and exhaust server
+    /// memory, CPU, or task capacity.
+    ///
+    /// Subscription IDs are tracked from the client's perspective (a `start`
+    /// increments the count, an explicit `stop` decrements it); a
+    /// subscription that completes on its own without the client sending
+    /// `stop` is not decremented until the connection ends. When the cap is
+    /// hit, an over-limit `start` message is silently dropped: the client
+    /// simply never receives `next`/`error`/`complete` for that id. This is
+    /// a deliberate, non-chatty mitigation, not a protocol error.
+    pub max_subscriptions: Option<usize>,
+
+    /// Called with the client's `connection_init` payload before any
+    /// operation is allowed to run; return `Err` to reject the connection
+    /// (e.g. invalid or missing auth token). This is the standard place
+    /// browser WebSocket clients put auth tokens, since custom headers
+    /// aren't available on a WS upgrade in browsers.
+    ///
+    /// `None` (the default) accepts every `connection_init`, matching
+    /// `async_graphql::http::WebSocket`'s own default.
+    pub on_connection_init: Option<OnConnectionInit>,
+}
+
+impl Default for WebSocketConfig {
+    fn default() -> Self {
+        Self {
+            keepalive_timeout: Some(Duration::from_secs(30)),
+            max_subscriptions: Some(100),
+            on_connection_init: None,
+        }
+    }
+}
+
+impl std::fmt::Debug for WebSocketConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebSocketConfig")
+            .field("keepalive_timeout", &self.keepalive_timeout)
+            .field("max_subscriptions", &self.max_subscriptions)
+            .field(
+                "on_connection_init",
+                &self.on_connection_init.as_ref().map(|_| "<callback>"),
+            )
+            .finish()
+    }
+}
+
+impl WebSocketConfig {
+    /// Set [`Self::keepalive_timeout`].
+    #[must_use]
+    pub fn with_keepalive_timeout(mut self, timeout: impl Into<Option<Duration>>) -> Self {
+        self.keepalive_timeout = timeout.into();
+        self
+    }
+
+    /// Set [`Self::max_subscriptions`].
+    #[must_use]
+    pub fn with_max_subscriptions(mut self, max: impl Into<Option<usize>>) -> Self {
+        self.max_subscriptions = max.into();
+        self
+    }
+
+    /// Set [`Self::on_connection_init`].
+    #[must_use]
+    pub fn with_on_connection_init<F, R>(mut self, callback: F) -> Self
+    where
+        F: FnOnce(serde_json::Value) -> R + Send + 'static,
+        R: std::future::Future<Output = GqlResult<Data>> + Send + 'static,
+    {
+        self.on_connection_init = Some(Box::new(|payload| Box::pin(callback(payload))));
+        self
+    }
+}
+
 /// Drive a GraphQL-over-WebSocket session to completion on an already
 /// upgraded connection.
 ///
-/// Runs until the client disconnects, sends `ConnectionTerminate`, or the
-/// connection is closed due to a protocol error (e.g. a keep-alive
-/// timeout). All queries, mutations, and subscriptions sent over the
-/// connection are executed against `executor` (typically an
-/// [`async_graphql::Schema`]); subscription result streams are pushed back
-/// to the client as they yield items.
+/// Runs until the client disconnects, sends `ConnectionTerminate`, the
+/// `connection_init` callback in `config` rejects the connection, the
+/// configured [`WebSocketConfig::keepalive_timeout`] fires because the
+/// client went silent, or a transport-level read/write error occurs. All
+/// queries, mutations, and subscriptions sent over the connection are
+/// executed against `executor` (typically an [`async_graphql::Schema`]);
+/// subscription result streams are pushed back to the client as they yield
+/// items, subject to `config`'s [`WebSocketConfig::max_subscriptions`] cap.
+///
+/// This always returns `Ok(())` on a clean protocol-level shutdown (client
+/// disconnect, `ConnectionTerminate`, keep-alive timeout, or a rejected
+/// `connection_init`); those are normal end-of-session outcomes reported to
+/// the client over the WebSocket itself, not out-of-band errors. Transport
+/// read errors and send failures are logged via `armature_log::warn!` and
+/// end the loop the same way a clean disconnect would, since by that point
+/// there is no live connection left to report an `Err` to.
 pub async fn serve_graphql_websocket<S, E>(
     ws_stream: WebSocketStream<S>,
     executor: E,
     protocol: Protocols,
+    config: WebSocketConfig,
 ) -> Result<(), ArmatureError>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
@@ -76,23 +192,62 @@ where
 {
     let (mut sink, stream) = ws_stream.split();
 
-    let input = stream.filter_map(|frame| async move {
-        match frame {
-            Ok(WsFrame::Text(text)) => Some(ClientMessage::from_bytes(text.as_bytes())),
+    let max_subscriptions = config.max_subscriptions;
+    let mut open_subscriptions: HashSet<String> = HashSet::new();
+
+    let input = stream.filter_map(move |frame| {
+        let result = match frame {
+            Ok(WsFrame::Text(text)) => match ClientMessage::from_bytes(text.as_bytes()) {
+                Ok(ClientMessage::Start { id, payload }) => {
+                    let at_cap = max_subscriptions.is_some_and(|max| {
+                        !open_subscriptions.contains(&id) && open_subscriptions.len() >= max
+                    });
+                    if at_cap {
+                        warn!(
+                            "graphql-ws: dropping subscribe id={id} - max_subscriptions cap reached"
+                        );
+                        None
+                    } else {
+                        open_subscriptions.insert(id.clone());
+                        Some(Ok(ClientMessage::Start { id, payload }))
+                    }
+                }
+                Ok(ClientMessage::Stop { id }) => {
+                    open_subscriptions.remove(&id);
+                    Some(Ok(ClientMessage::Stop { id }))
+                }
+                Ok(other) => Some(Ok(other)),
+                Err(err) => Some(Err(err)),
+            },
             // Binary/Ping/Pong/Close frames carry no graphql-ws protocol
             // message; skip them and keep reading. tokio-tungstenite
             // answers protocol-level Pings automatically, and a Close
             // frame ends the underlying stream on its own on the next poll.
             Ok(_) => None,
             // A transport-level error also ends the underlying stream on
-            // the next poll; there is no graphql-ws message to report it as.
-            Err(_) => None,
-        }
+            // the next poll; log it since there is no graphql-ws message to
+            // report it as.
+            Err(err) => {
+                warn!("graphql-ws: transport read error: {err}");
+                None
+            }
+        };
+        async move { result }
     });
 
-    let mut gql_ws = Box::pin(http::WebSocket::from_message_stream(
-        executor, input, protocol,
-    ));
+    // Always route through `on_connection_init` with a boxed callback (even
+    // when the caller supplied none) so both branches share one concrete
+    // `WebSocket<..>` type; a `None` config falls back to async-graphql's
+    // own default (always-accept) initializer.
+    let on_connection_init: OnConnectionInit = config.on_connection_init.unwrap_or_else(|| {
+        Box::new(|payload| Box::pin(async move { http::default_on_connection_init(payload).await }))
+    });
+
+    let mut gql_ws = Box::pin(
+        http::WebSocket::from_message_stream(executor, input, protocol)
+            .keepalive_timeout(config.keepalive_timeout)
+            .on_connection_init(on_connection_init),
+    );
 
     while let Some(message) = gql_ws.next().await {
         let (frame, is_close) = match message {
@@ -106,7 +261,8 @@ where
             ),
         };
 
-        if sink.send(frame).await.is_err() {
+        if let Err(err) = sink.send(frame).await {
+            warn!("graphql-ws: failed to send frame to client: {err}");
             break;
         }
         if is_close {
@@ -197,6 +353,7 @@ mod tests {
             server,
             test_schema(),
             Protocols::GraphQLWS,
+            WebSocketConfig::default(),
         ));
 
         client
@@ -242,6 +399,7 @@ mod tests {
             server,
             test_schema(),
             Protocols::GraphQLWS,
+            WebSocketConfig::default(),
         ));
 
         client
@@ -279,5 +437,200 @@ mod tests {
         client.send(WsFrame::Close(None)).await.unwrap();
         drop(client);
         let _ = serve.await;
+    }
+
+    #[tokio::test]
+    async fn connection_terminate_ends_the_session() {
+        let (server, mut client) = websocket_pair().await;
+
+        let serve = tokio::spawn(serve_graphql_websocket(
+            server,
+            test_schema(),
+            Protocols::GraphQLWS,
+            WebSocketConfig::default(),
+        ));
+
+        client
+            .send(WsFrame::Text(
+                serde_json::json!({"type": "connection_init"})
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+        client.next().await.unwrap().unwrap(); // connection_ack
+
+        client
+            .send(WsFrame::Text(
+                serde_json::json!({"type": "connection_terminate"})
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+
+        // The server ends the stream on its side in response to
+        // `connection_terminate`; the client either observes the resulting
+        // close frame or the connection simply ending.
+        match client.next().await {
+            None => {}
+            Some(Ok(frame)) => assert!(frame.is_close()),
+            Some(Err(_)) => {}
+        }
+
+        let result = tokio::time::timeout(Duration::from_secs(5), serve)
+            .await
+            .expect("serve_graphql_websocket did not return after connection_terminate")
+            .unwrap();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn keepalive_timeout_closes_idle_connection() {
+        let (server, mut client) = websocket_pair().await;
+
+        let config = WebSocketConfig::default().with_keepalive_timeout(Duration::from_millis(100));
+        let serve = tokio::spawn(serve_graphql_websocket(
+            server,
+            test_schema(),
+            Protocols::GraphQLWS,
+            config,
+        ));
+
+        client
+            .send(WsFrame::Text(
+                serde_json::json!({"type": "connection_init"})
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+        client.next().await.unwrap().unwrap(); // connection_ack
+
+        // Stay silent from here on; the keepalive timer should fire and the
+        // server should close the connection on its own, rather than hang
+        // forever waiting on an unresponsive client.
+        let closed = tokio::time::timeout(Duration::from_secs(5), client.next())
+            .await
+            .expect("keepalive_timeout did not fire")
+            .unwrap()
+            .unwrap();
+        assert!(closed.is_close());
+
+        let result = tokio::time::timeout(Duration::from_secs(5), serve)
+            .await
+            .expect("serve_graphql_websocket did not return after keepalive timeout")
+            .unwrap();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn max_subscriptions_cap_drops_over_limit_subscribe() {
+        let (server, mut client) = websocket_pair().await;
+
+        let config = WebSocketConfig::default().with_max_subscriptions(1);
+        let serve = tokio::spawn(serve_graphql_websocket(
+            server,
+            test_schema(),
+            Protocols::GraphQLWS,
+            config,
+        ));
+
+        client
+            .send(WsFrame::Text(
+                serde_json::json!({"type": "connection_init"})
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+        client.next().await.unwrap().unwrap(); // connection_ack
+
+        client
+            .send(WsFrame::Text(
+                serde_json::json!({
+                    "id": "sub-1",
+                    "type": "subscribe",
+                    "payload": {"query": "subscription { counter }"}
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+
+        // Sent while sub-1 is already open and the cap is 1; this subscribe
+        // should be silently dropped and never produce output.
+        client
+            .send(WsFrame::Text(
+                serde_json::json!({
+                    "id": "sub-2",
+                    "type": "subscribe",
+                    "payload": {"query": "query { hello }"}
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+
+        let mut saw_sub2 = false;
+        loop {
+            let msg = client.next().await.unwrap().unwrap();
+            let text = msg.into_text().unwrap();
+            if text.contains("\"id\":\"sub-2\"") {
+                saw_sub2 = true;
+            }
+            if text.contains("complete") {
+                break;
+            }
+        }
+        assert!(
+            !saw_sub2,
+            "over-limit subscription should never produce output"
+        );
+
+        drop(client);
+        let _ = serve.await;
+    }
+
+    #[tokio::test]
+    async fn rejected_connection_init_closes_the_session() {
+        let (server, mut client) = websocket_pair().await;
+
+        let config = WebSocketConfig::default().with_on_connection_init(|payload| async move {
+            if payload.get("token").and_then(|t| t.as_str()) == Some("secret") {
+                Ok(Data::default())
+            } else {
+                Err(async_graphql::Error::new("unauthorized"))
+            }
+        });
+        let serve = tokio::spawn(serve_graphql_websocket(
+            server,
+            test_schema(),
+            Protocols::GraphQLWS,
+            config,
+        ));
+
+        client
+            .send(WsFrame::Text(
+                serde_json::json!({
+                    "type": "connection_init",
+                    "payload": {"token": "wrong"}
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+
+        let closed = client.next().await.unwrap().unwrap();
+        assert!(closed.is_close());
+
+        let result = tokio::time::timeout(Duration::from_secs(5), serve)
+            .await
+            .expect("serve_graphql_websocket did not return after rejected connection_init")
+            .unwrap();
+        assert!(result.is_ok());
     }
 }

--- a/armature-graphql/src/websocket.rs
+++ b/armature-graphql/src/websocket.rs
@@ -1,0 +1,283 @@
+//! GraphQL subscriptions over WebSocket.
+//!
+//! Implements both the legacy `graphql-ws` (subscriptions-transport-ws) and
+//! the current `graphql-transport-ws` sub-protocols by driving
+//! [`async_graphql::http::WebSocket`] against a caller-supplied
+//! [`tokio_tungstenite::WebSocketStream`].
+//!
+//! This module is transport-agnostic on purpose: it does not perform the
+//! HTTP `Upgrade` handshake or accept a TCP connection itself. The caller
+//! (typically an `armature-core` route handler) is responsible for:
+//!
+//! 1. Negotiating the sub-protocol from the client's `Sec-WebSocket-Protocol`
+//!    request header via [`select_protocol`].
+//! 2. Completing the WebSocket upgrade and producing a
+//!    [`tokio_tungstenite::WebSocketStream`].
+//! 3. Calling [`serve_graphql_websocket`] with that stream and the built
+//!    [`async_graphql::Schema`].
+//!
+//! Only text frames are treated as GraphQL-over-WebSocket protocol messages;
+//! binary frames are ignored, matching the text-only `graphql-ws` /
+//! `graphql-transport-ws` specs. Ping/Pong at the WebSocket-frame level are
+//! left to `tokio-tungstenite`'s own automatic handling, consistent with
+//! [`armature_core::websocket::handle_websocket`].
+
+use armature_core::Error as ArmatureError;
+use async_graphql::Executor;
+use async_graphql::futures_util::{SinkExt, StreamExt};
+use async_graphql::http::{self, ClientMessage};
+use tokio_tungstenite::WebSocketStream;
+use tokio_tungstenite::tungstenite::Message as WsFrame;
+use tokio_tungstenite::tungstenite::protocol::CloseFrame;
+
+pub use async_graphql::http::ALL_WEBSOCKET_PROTOCOLS;
+pub use async_graphql::http::WebSocketProtocols as Protocols;
+
+/// Select a `graphql-ws`/`graphql-transport-ws` sub-protocol from the value
+/// of an incoming `Sec-WebSocket-Protocol` request header.
+///
+/// The header may list multiple client-offered protocols separated by
+/// commas (per RFC 6455); the first one this server understands is chosen.
+/// Returns an error if the header is absent or none of the offered
+/// protocols are supported, in which case the caller should reject the
+/// upgrade (e.g. with `426 Upgrade Required`) instead of proceeding.
+pub fn select_protocol(header_value: Option<&str>) -> Result<Protocols, ArmatureError> {
+    let header_value = header_value
+        .ok_or_else(|| ArmatureError::BadRequest("Missing Sec-WebSocket-Protocol".to_string()))?;
+
+    header_value
+        .split(',')
+        .map(str::trim)
+        .find_map(|candidate| candidate.parse::<Protocols>().ok())
+        .ok_or_else(|| {
+            ArmatureError::BadRequest(format!(
+                "Unsupported Sec-WebSocket-Protocol: {header_value}"
+            ))
+        })
+}
+
+/// Drive a GraphQL-over-WebSocket session to completion on an already
+/// upgraded connection.
+///
+/// Runs until the client disconnects, sends `ConnectionTerminate`, or the
+/// connection is closed due to a protocol error (e.g. a keep-alive
+/// timeout). All queries, mutations, and subscriptions sent over the
+/// connection are executed against `executor` (typically an
+/// [`async_graphql::Schema`]); subscription result streams are pushed back
+/// to the client as they yield items.
+pub async fn serve_graphql_websocket<S, E>(
+    ws_stream: WebSocketStream<S>,
+    executor: E,
+    protocol: Protocols,
+) -> Result<(), ArmatureError>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    E: Executor,
+{
+    let (mut sink, stream) = ws_stream.split();
+
+    let input = stream.filter_map(|frame| async move {
+        match frame {
+            Ok(WsFrame::Text(text)) => Some(ClientMessage::from_bytes(text.as_bytes())),
+            // Binary/Ping/Pong/Close frames carry no graphql-ws protocol
+            // message; skip them and keep reading. tokio-tungstenite
+            // answers protocol-level Pings automatically, and a Close
+            // frame ends the underlying stream on its own on the next poll.
+            Ok(_) => None,
+            // A transport-level error also ends the underlying stream on
+            // the next poll; there is no graphql-ws message to report it as.
+            Err(_) => None,
+        }
+    });
+
+    let mut gql_ws = Box::pin(http::WebSocket::from_message_stream(
+        executor, input, protocol,
+    ));
+
+    while let Some(message) = gql_ws.next().await {
+        let (frame, is_close) = match message {
+            http::WsMessage::Text(text) => (WsFrame::Text(text.into()), false),
+            http::WsMessage::Close(code, reason) => (
+                WsFrame::Close(Some(CloseFrame {
+                    code: code.into(),
+                    reason: reason.into(),
+                })),
+                true,
+            ),
+        };
+
+        if sink.send(frame).await.is_err() {
+            break;
+        }
+        if is_close {
+            break;
+        }
+    }
+
+    let _ = sink.close().await;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_graphql::{EmptyMutation, Object, Schema, Subscription};
+
+    struct Query;
+
+    #[Object]
+    impl Query {
+        async fn hello(&self) -> &str {
+            "world"
+        }
+    }
+
+    struct SubscriptionRoot;
+
+    #[Subscription]
+    impl SubscriptionRoot {
+        async fn counter(&self) -> impl async_graphql::futures_util::Stream<Item = i32> {
+            async_graphql::futures_util::stream::iter(0..3)
+        }
+    }
+
+    type TestSchema = Schema<Query, EmptyMutation, SubscriptionRoot>;
+
+    fn test_schema() -> TestSchema {
+        Schema::new(Query, EmptyMutation, SubscriptionRoot)
+    }
+
+    #[test]
+    fn select_protocol_picks_first_supported_offer() {
+        assert_eq!(
+            select_protocol(Some("graphql-transport-ws")).unwrap(),
+            Protocols::GraphQLWS
+        );
+        assert_eq!(
+            select_protocol(Some("graphql-ws")).unwrap(),
+            Protocols::SubscriptionsTransportWS
+        );
+        assert_eq!(
+            select_protocol(Some("bogus, graphql-transport-ws")).unwrap(),
+            Protocols::GraphQLWS
+        );
+    }
+
+    #[test]
+    fn select_protocol_rejects_missing_or_unsupported_header() {
+        assert!(select_protocol(None).is_err());
+        assert!(select_protocol(Some("bogus-protocol")).is_err());
+    }
+
+    async fn websocket_pair() -> (
+        WebSocketStream<tokio::io::DuplexStream>,
+        WebSocketStream<tokio::io::DuplexStream>,
+    ) {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let server = WebSocketStream::from_raw_socket(
+            server_io,
+            tokio_tungstenite::tungstenite::protocol::Role::Server,
+            None,
+        )
+        .await;
+        let client = WebSocketStream::from_raw_socket(
+            client_io,
+            tokio_tungstenite::tungstenite::protocol::Role::Client,
+            None,
+        )
+        .await;
+        (server, client)
+    }
+
+    #[tokio::test]
+    async fn executes_a_query_over_the_websocket_transport() {
+        let (server, mut client) = websocket_pair().await;
+
+        let serve = tokio::spawn(serve_graphql_websocket(
+            server,
+            test_schema(),
+            Protocols::GraphQLWS,
+        ));
+
+        client
+            .send(WsFrame::Text(
+                serde_json::json!({"type": "connection_init"})
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+        let ack = client.next().await.unwrap().unwrap();
+        assert!(ack.into_text().unwrap().contains("connection_ack"));
+
+        client
+            .send(WsFrame::Text(
+                serde_json::json!({
+                    "id": "1",
+                    "type": "subscribe",
+                    "payload": {"query": "query { hello }"}
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let next = client.next().await.unwrap().unwrap();
+        let text = next.into_text().unwrap();
+        assert!(text.contains("\"hello\":\"world\""));
+        assert!(text.contains("\"id\":\"1\""));
+
+        let complete = client.next().await.unwrap().unwrap();
+        assert!(complete.into_text().unwrap().contains("complete"));
+
+        drop(client);
+        let _ = serve.await;
+    }
+
+    #[tokio::test]
+    async fn streams_subscription_results_and_completes() {
+        let (server, mut client) = websocket_pair().await;
+
+        let serve = tokio::spawn(serve_graphql_websocket(
+            server,
+            test_schema(),
+            Protocols::GraphQLWS,
+        ));
+
+        client
+            .send(WsFrame::Text(
+                serde_json::json!({"type": "connection_init"})
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+        client.next().await.unwrap().unwrap(); // connection_ack
+
+        client
+            .send(WsFrame::Text(
+                serde_json::json!({
+                    "id": "sub-1",
+                    "type": "subscribe",
+                    "payload": {"query": "subscription { counter }"}
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+
+        for expected in 0..3 {
+            let msg = client.next().await.unwrap().unwrap();
+            let text = msg.into_text().unwrap();
+            assert!(text.contains(&format!("\"counter\":{expected}")));
+        }
+
+        let complete = client.next().await.unwrap().unwrap();
+        assert!(complete.into_text().unwrap().contains("complete"));
+
+        client.send(WsFrame::Close(None)).await.unwrap();
+        drop(client);
+        let _ = serve.await;
+    }
+}

--- a/armature-graphql/tests/resolver_macro_test.rs
+++ b/armature-graphql/tests/resolver_macro_test.rs
@@ -1,0 +1,117 @@
+//! Integration tests for the `#[resolver]` decorator macro: verifies that a
+//! single `impl` block mixing `#[query]`/`#[mutation]`/`#[subscription]`
+//! methods (NestJS-`@Resolver()`-style) actually executes through a real
+//! `async_graphql::Schema`, end to end.
+
+use armature_graphql::async_graphql::futures_util::{Stream, StreamExt};
+use armature_graphql::async_graphql::{ID, Schema, SimpleObject};
+use armature_graphql::resolver;
+
+#[derive(SimpleObject, Clone)]
+pub struct User {
+    id: ID,
+    name: String,
+}
+
+#[derive(Clone, Default)]
+pub struct UserResolver {
+    // Stands in for a DI-injected service the resolver depends on.
+    greeting: String,
+}
+
+#[resolver]
+impl UserResolver {
+    #[query]
+    async fn user(&self, id: ID) -> User {
+        User {
+            id,
+            name: format!("{}user", self.greeting),
+        }
+    }
+
+    #[mutation]
+    async fn create_user(&self, name: String) -> User {
+        User {
+            id: ID::from("new"),
+            name,
+        }
+    }
+
+    #[subscription]
+    async fn counter(&self) -> impl Stream<Item = i32> {
+        armature_graphql::async_graphql::futures_util::stream::iter(0..3)
+    }
+
+    // Untagged helper methods stay on the original type and are not
+    // exposed as GraphQL fields.
+    fn helper(&self) -> &str {
+        "not a field"
+    }
+}
+
+#[derive(armature_graphql::async_graphql::MergedObject)]
+struct Query(UserResolverQuery);
+
+#[derive(armature_graphql::async_graphql::MergedObject)]
+struct Mutation(UserResolverMutation);
+
+type Sub = UserResolverSubscription;
+
+type AppSchema = Schema<Query, Mutation, Sub>;
+
+fn build_schema() -> AppSchema {
+    let resolver = UserResolver {
+        greeting: "hello-".to_string(),
+    };
+    Schema::build(
+        Query(UserResolverQuery::from(resolver.clone())),
+        Mutation(UserResolverMutation::from(resolver.clone())),
+        UserResolverSubscription::from(resolver),
+    )
+    .finish()
+}
+
+#[tokio::test]
+async fn query_field_executes_through_the_generated_wrapper() {
+    let schema = build_schema();
+    let res = schema.execute(r#"{ user(id: "1") { id name } }"#).await;
+    assert!(res.errors.is_empty(), "{:?}", res.errors);
+    let data = serde_json::to_value(res.data).unwrap();
+    assert_eq!(data["user"]["id"], "1");
+    assert_eq!(data["user"]["name"], "hello-user");
+}
+
+#[tokio::test]
+async fn mutation_field_executes_through_the_generated_wrapper() {
+    let schema = build_schema();
+    let res = schema
+        .execute(r#"mutation { createUser(name: "Ada") { id name } }"#)
+        .await;
+    assert!(res.errors.is_empty(), "{:?}", res.errors);
+    let data = serde_json::to_value(res.data).unwrap();
+    assert_eq!(data["createUser"]["name"], "Ada");
+}
+
+#[tokio::test]
+async fn subscription_field_streams_through_the_generated_wrapper() {
+    let schema = build_schema();
+    let mut stream = schema.execute_stream(r#"subscription { counter }"#);
+
+    for expected in 0..3 {
+        let res = stream.next().await.unwrap();
+        assert!(res.errors.is_empty(), "{:?}", res.errors);
+        let data = serde_json::to_value(res.data).unwrap();
+        assert_eq!(data["counter"], expected);
+    }
+    assert!(stream.next().await.is_none());
+}
+
+#[test]
+fn untagged_methods_are_not_exposed_as_graphql_fields() {
+    let resolver = UserResolver {
+        greeting: "hi-".to_string(),
+    };
+    // Compiles only if `helper` stayed on the original type instead of
+    // being moved into one of the generated wrapper types.
+    assert_eq!(resolver.helper(), "not a field");
+}


### PR DESCRIPTION
## Summary

Two additions to `armature-graphql`, plus a full `/audit` + `/code-review` reconciliation pass:

1. **WebSocket transport for subscriptions** (new `websocket` feature, `armature-graphql/src/websocket.rs`). Transport-agnostic: drives async-graphql's own `graphql-ws`/`graphql-transport-ws` protocol state machine against a caller-supplied `tokio_tungstenite::WebSocketStream`. Includes `select_protocol` for `Sec-WebSocket-Protocol` negotiation, and a `WebSocketConfig` (keep-alive timeout, per-connection subscription cap, `connection_init` auth hook) hardening it against abuse. Removed the unused `async-graphql-axum` dependency.

2. **`#[resolver]` decorator macro** (new `armature-graphql-macros` crate). Lets a single `impl` block mix `#[query]`/`#[mutation]`/`#[subscription]`-tagged methods — mirroring NestJS's `@Resolver()`/`@Query()`/`@Mutation()`/`@Subscription()` — splitting them at compile time into the separate wrapper types async-graphql needs, each still driven by async-graphql's real `#[Object]`/`#[Subscription]` macros. Composable via `MergedObject`/`MergedSubscription`. Also extends the static SDL analyzer (`sdl_static.rs`) to recognize the new markers.

3. **Reconciliation commit**: full `/audit` (2 agents) + `/code-review` (4 agents, 7 domains) pass on both crates, converged to 0 Critical/Warning findings. Fixed: the keep-alive timeout the docs claimed but never wired, an unbounded-subscriptions DoS gap, silently-swallowed transport errors, dropped interface-field arguments in the static SDL analyzer, dead shadowed code (`schema_builder::EmptyMutation`/`EmptySubscription`), several stale doc claims, and added missing test coverage throughout (including a previously-unused `trybuild` dependency).

## Test plan
- [x] `cargo check --workspace --all-features` clean
- [x] `cargo +stable clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Full workspace test suite (233 suites, 0 failures)
- [x] New coverage: websocket duplex-stream integration tests exercising the real graphql-ws protocol (query/mutation/subscription/terminate/timeout/cap/auth-rejection); resolver macro unit tests for every error path plus end-to-end query/mutation/subscription execution through a real `Schema`; a `trybuild` UI pass test

🤖 Generated with [Claude Code](https://claude.com/claude-code)