### PR TITLE
chore(release): bump armature-core to 0.6.0, armature-graphql to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`armature-graphql-macros` `0.1.0` (new crate):** `#[resolver]` attribute macro, re-exported from `armature-graphql`. Lets a single `impl` block mix `#[query]`/`#[mutation]`/`#[subscription]`-tagged methods — mirroring NestJS's `@Resolver()`/`@Query()`/`@Mutation()`/`@Subscription()` — and splits them at compile time into the separate `<Type>Query`/`<Type>Mutation`/`<Type>Subscription` wrapper types `async-graphql` needs, each still driven by `async-graphql`'s real `#[Object]`/`#[Subscription]` macros.
+- **`armature-graphql` `0.3.0` → `0.4.0`:** GraphQL subscriptions over WebSocket (new `websocket` feature) — drives `async-graphql`'s `graphql-ws`/`graphql-transport-ws` protocol over a caller-supplied `tokio_tungstenite::WebSocketStream`, with a `WebSocketConfig` (keep-alive timeout, per-connection subscription cap, `connection_init` auth hook) for abuse-resistance. Static SDL analyzer (`sdl-export` feature) extended to recognize `#[resolver]`'s markers and to fully parse `#[derive(Interface)]` field arguments/descriptions/deprecation.
+  - **Breaking:** the old `#[macro_export] macro_rules! resolver!` in `decorators.rs` is removed, superseded by the `#[resolver]` attribute macro (different invocation syntax — an attribute, not a declarative macro call). No in-tree consumer used it.
+  - Removed the unused `async-graphql-axum` dependency.
+
+### Fixed
+
+- **Breaking (`armature-core`) — `0.5.0` → `0.6.0`:** full `/audit` reconciliation (22 findings). `Cors::call` now validates `Origin` against `allowed_origins` instead of always echoing the first configured origin (was silently permissive for any origin). `set_thread_affinity_linux` bounds `core` against `min(num_cpus(), 64)`, preventing a `u64` mask shift overflow. `pipeline.rs`'s `max_buf_size` clamped to hyper's 8192-byte minimum, fixing a panic against the `low_latency()`/`memory_efficient()` presets. `Query`/`PathParams` extractors re-percent-encode key/value pairs to avoid misparsing decoded values containing literal `&`/`=`. `TimeoutConfig::get_timeout_for_path` now does longest-prefix-match instead of first-`HashMap`-iteration-order-match. **Breaking:** `memory_opt::init_pools` now returns `bool` (`true` if it performed initialization, `false` if a pool was already set) instead of `()`. Removed the unused `matchit` dependency.
+
 ## [0.3.0] - 2026-07-29
 
 ### Security

--- a/armature-core/Cargo.toml
+++ b/armature-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "armature-core"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/armature-graphql/Cargo.toml
+++ b/armature-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "armature-graphql"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/templates/api-full/Cargo.toml
+++ b/templates/api-full/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.94.1"
 # Cargo will resolve the wrong crate entirely.
 armature = { package = "armature-framework", version = "0", features = ["auth", "jwt", "validation"] }
 # armature-core is required directly because armature's macro-expanded code references armature_core:: paths that aren't currently re-exported through the armature facade crate.
-armature-core = "0.5"
+armature-core = "0"
 
 # Async trait for middleware
 async-trait = "0.1"

--- a/templates/api-minimal/Cargo.toml
+++ b/templates/api-minimal/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.94.1"
 # `armature` so `use armature::...` in this crate's source keeps working.
 armature = { version = "0", package = "armature-framework" }
 # armature-core is required directly because armature's macro-expanded code references armature_core:: paths that aren't currently re-exported through the armature facade crate.
-armature-core = "0.5"
+armature-core = "0"
 async-trait = "0.1"
 tokio = { version = "1.35", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/templates/graphql-api/Cargo.toml
+++ b/templates/graphql-api/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.94.1"
 # this crate's `[lib] name = "armature"`.
 armature = { package = "armature-framework", version = "0", features = ["graphql", "validation"] }
 # armature-core is required directly because armature's macro-expanded code references armature_core:: paths that aren't currently re-exported through the armature facade crate.
-armature-core = "0.5"
+armature-core = "0"
 async-graphql = { version = "7.0", features = ["chrono", "uuid"] }
 
 # Required for controller/module macros

--- a/templates/microservice/Cargo.toml
+++ b/templates/microservice/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.94.1"
 # -- must be pulled in under an explicit `package` rename.
 armature = { package = "armature-framework", version = "0", features = ["queue"] }
 # armature-core is required directly because armature's macro-expanded code references armature_core:: paths that aren't currently re-exported through the armature facade crate.
-armature-core = "0.5"
+armature-core = "0"
 async-trait = "0.1"
 
 # Runtime


### PR DESCRIPTION
## Summary
Version bumps for this session's already-merged work, ahead of publishing `armature-core`, `armature-graphql`, and the new `armature-graphql-macros` to crates.io:

- **`armature-core` 0.5.0 → 0.6.0** (minor, not patch): the full `/audit` reconciliation (Cors origin validation, thread-affinity overflow guard, `pipeline.rs` `max_buf_size` panic fix, extractor percent-encoding fix, longest-prefix timeout matching, and others). Bumped past patch because `memory_opt::init_pools`'s return type changed from `()` to `bool` — a real signature-level break.
- **`armature-graphql` 0.3.0 → 0.4.0**: GraphQL subscriptions over WebSocket (new `websocket` feature) and the `#[resolver]` decorator macro (re-exported from the new `armature-graphql-macros` crate). Bumped past patch because the old `macro_rules! resolver!` was removed outright (no deprecation shim — zero in-tree consumers).
- **`armature-graphql-macros` stays at `0.1.0`** for its first publish.

All three crates' internal `armature-*` dependencies are already pinned via caret `"0"`, so no downstream repin is needed anywhere in the workspace.

`CHANGELOG.md` updated with an `[Unreleased]` entry covering all three.

## Test plan
- [x] `cargo check --workspace --all-features` clean
- [x] `cargo +stable clippy --workspace --all-targets --all-features -- -D warnings` clean (pre-commit hook)
- [x] Full workspace test suite passing (pre-push hook)
- [ ] Publish to crates.io after this merges (per explicit instruction, not automated here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)