### PR TITLE
chore(release): re-publish jwt, ratelimit, testing and mcp for core 0.7

### DIFF
--- a/armature-jwt/Cargo.toml
+++ b/armature-jwt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "armature-jwt"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/armature-mcp/Cargo.toml
+++ b/armature-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "armature-mcp"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 # Inherits the workspace MSRV (1.94.1). This crate's own floor is 1.91 — the
 # `register_mcp_tool!` macro expands to an `inventory::submit!` `static` whose

--- a/armature-ratelimit/Cargo.toml
+++ b/armature-ratelimit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "armature-ratelimit"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/armature-testing/Cargo.toml
+++ b/armature-testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "armature-testing"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Four crates are the only ones whose **published** manifests still require `armature-core ^0.5.0`. In-repo they have declared `armature-core = { path = "...", version = "0" }` since #270 loosened internal `armature-*` requirements to caret `"0"` — they were simply last published before that landed, so crates.io still advertises the old, tight bound.

## Why this is not cosmetic

A downstream crate that depends on `armature-core` directly **and** on any of these cannot move past core 0.5. Cargo treats `0.5` and `0.6` as incompatible ranges and will not unify them, so the build resolves two copies of `armature-core`. That is a type-identity problem, not a size one — types do not cross between the copies:

```
error[E0308]: mismatched types
  expected `armature_core::http::HttpRequest`, found `HttpRequest`
note: there are multiple different versions of crate `armature_core`
      in the dependency graph
```

That is exactly what happens the moment a consumer hands an `armature_core` type to `armature_mcp`'s `McpController`. Reproduced downstream in condukt, which is blocked on it.

## Changes

| crate | version | reason |
|---|---|---|
| `armature-jwt` | 0.2.0 → 0.2.1 | ship the caret `"0"` core requirement |
| `armature-ratelimit` | 0.2.0 → 0.2.1 | same |
| `armature-testing` | 0.2.0 → 0.2.1 | same |
| `armature-mcp` | 0.1.4 → 0.1.5 | same |

**No code changes** — re-publishing with the current manifests is the entire fix. Patch bumps, because the only difference from each crate's last release is a *widened* dependency requirement, which cannot break an existing consumer.

Not touched here:
- `armature-core` is already 0.7.0 from #275 (tower_compat removal — breaking, hence the minor bump).
- `armature-graphql` 0.4.0 and `armature-graphql-macros` 0.1.0 are unchanged and already on crates.io. `scripts/publish.sh` returns *skipped (already published)* for existing versions unless `--force`, so a release run is safe over them.

## Verification

- `cargo test` across `armature-core`, `-jwt`, `-ratelimit`, `-testing`, `-mcp`, `-graphql`, `-graphql-macros`: **27 suites, 1598 tests, 0 failures**
- workspace `fmt` + `clippy` clean (pre-commit hook on every commit)

## After merge

Release is tag-driven (`release.yml` on `v[0-9]+.[0-9]+.[0-9]+` → `scripts/publish.sh --yes`). Latest tag is `v0.3.0`, so this wants `v0.4.0` once merged to `main`.