### PR TITLE
fix(husky): decide pre-push from pushed refs; bump root crate to 0.4.0

### DIFF
--- a/.cargo-husky/hooks/pre-push
+++ b/.cargo-husky/hooks/pre-push
@@ -7,15 +7,36 @@ set -e
 echo "🚀 Running pre-push checks..."
 echo ""
 
-# Get the current branch name
-current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+# Refuse direct pushes to protected branches.
+#
+# Decided from the refs actually being pushed, which git supplies on stdin as
+# "<local ref> <local sha> <remote ref> <remote sha>" per ref — NOT from
+# `git symbolic-ref HEAD`. The old check read the checked-out branch, so it
+# rejected any push made while `main` happened to be checked out even when the
+# ref being pushed was something else entirely. Pushing a release tag was
+# impossible for that reason: `git push origin v0.4.0` from `main` was refused
+# although the ref was `refs/tags/v0.4.0` and no branch was being updated.
+#
+# stdin is consumed here, so it is captured first for anything added later.
+pushed_refs=$(cat)
 
-# Check if pushing to protected branches
-if [ "$current_branch" = "main" ] || [ "$current_branch" = "master" ]; then
-    echo "❌ Direct push to '$current_branch' is not allowed!"
+if printf '%s\n' "$pushed_refs" \
+    | awk '{ print $3 }' \
+    | grep -qE '^refs/heads/(main|master)$'; then
+    echo "❌ Direct push to a protected branch (main/master) is not allowed!"
     echo "   Please create a pull request instead."
     echo ""
     exit 1
+fi
+
+# A delete (remote sha all zeros with a zero local sha) and a tag push do not
+# need the compile/test gate below — nothing new is being introduced to a
+# branch. Skip straight to allowing it.
+if [ -n "$pushed_refs" ] && ! printf '%s\n' "$pushed_refs" \
+    | awk '{ print $3 }' | grep -qE '^refs/heads/'; then
+    echo "ℹ️  No branch refs in this push (tags only) — skipping compile/test gate."
+    echo ""
+    exit 0
 fi
 
 # 1. Run quick compile check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ homepage = "https://quinnjr.github.io/armature"
 
 [package]
 name = "armature-framework"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.94.1"
 autobenches = false  # Disable auto-discovery, use explicit [[bench]] only


### PR DESCRIPTION
Two fixes that surfaced while cutting v0.4.0.

## pre-push decided from the wrong thing

It used `git symbolic-ref --short HEAD` — the *checked-out* branch — instead of the refs git supplies on stdin as `<local ref> <local sha> <remote ref> <remote sha>`. So any push made while `main` happened to be checked out was rejected even when no branch was being updated: `git push origin v0.4.0` from `main` failed with *"Direct push to 'main' is not allowed"* although the ref was `refs/tags/v0.4.0`. Cutting a release tag was impossible without `--no-verify` — disabling the hook entirely, which is the one thing a hook exists to prevent.

Now read from stdin and matched with an anchored `^refs/heads/(main|master)$`. Each case verified rather than assumed:

| push | result |
|---|---|
| `main` / `master` | BLOCKED |
| tag **+** main together | BLOCKED — a mixed push is not a loophole |
| `develop` / feature branch | gated (check + tests) |
| tag only | allowed, gate skipped |
| branch named `mainline` | gated, **not** blocked (anchored) |

A tag-only push also skips the compile/test gate: nothing new reaches a branch, and the tagged commit is already on one where it was gated when it landed.

## Root crate version

It was 0.3.0 — the version already on crates.io — while this release is v0.4.0. `release.yml`'s final step is a bare `cargo publish -p armature-framework` with no already-published guard, so the v0.4.0 run failed exactly there:

```
Create Release:       success
Publish to crates.io: failure
  step: Publish armature-framework (root crate)
```

Both v0.3.0 runs failed identically, so this is long-standing rather than new. Bumped to 0.4.0 so the facade matches the tag and that step can succeed.

Only `[package]` is touched — `[workspace.package]` stays at 0.2.0, since members inherit that and are versioned independently. `cargo metadata` confirms the root resolves as 0.4.0.

## Follow-ups (not in this PR)

- That final step should get the same skip-if-already-published behaviour `publish.sh` already has (`return 2 = skipped`), so a re-run or a no-op release does not go red.
- cargo-husky installs `.cargo-husky/hooks/` into `.git/hooks/` at build time, so the hook fix only becomes active locally after the next workspace build.