### PR TITLE
chore(release): bring main up to develop (root crate 0.4.0)

### DIFF
--- a/.cargo-husky/hooks/pre-push
+++ b/.cargo-husky/hooks/pre-push
@@ -7,15 +7,36 @@ set -e
 echo "🚀 Running pre-push checks..."
 echo ""
 
-# Get the current branch name
-current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+# Refuse direct pushes to protected branches.
+#
+# Decided from the refs actually being pushed, which git supplies on stdin as
+# "<local ref> <local sha> <remote ref> <remote sha>" per ref — NOT from
+# `git symbolic-ref HEAD`. The old check read the checked-out branch, so it
+# rejected any push made while `main` happened to be checked out even when the
+# ref being pushed was something else entirely. Pushing a release tag was
+# impossible for that reason: `git push origin v0.4.0` from `main` was refused
+# although the ref was `refs/tags/v0.4.0` and no branch was being updated.
+#
+# stdin is consumed here, so it is captured first for anything added later.
+pushed_refs=$(cat)
 
-# Check if pushing to protected branches
-if [ "$current_branch" = "main" ] || [ "$current_branch" = "master" ]; then
-    echo "❌ Direct push to '$current_branch' is not allowed!"
+if printf '%s\n' "$pushed_refs" \
+    | awk '{ print $3 }' \
+    | grep -qE '^refs/heads/(main|master)$'; then
+    echo "❌ Direct push to a protected branch (main/master) is not allowed!"
     echo "   Please create a pull request instead."
     echo ""
     exit 1
+fi
+
+# A delete (remote sha all zeros with a zero local sha) and a tag push do not
+# need the compile/test gate below — nothing new is being introduced to a
+# branch. Skip straight to allowing it.
+if [ -n "$pushed_refs" ] && ! printf '%s\n' "$pushed_refs" \
+    | awk '{ print $3 }' | grep -qE '^refs/heads/'; then
+    echo "ℹ️  No branch refs in this push (tags only) — skipping compile/test gate."
+    echo ""
+    exit 0
 fi
 
 # 1. Run quick compile check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ homepage = "https://quinnjr.github.io/armature"
 
 [package]
 name = "armature-framework"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.94.1"
 autobenches = false  # Disable auto-discovery, use explicit [[bench]] only


### PR DESCRIPTION
Tree byte-identical to `origin/develop`. Based on `main` for the reason in #280: linear history required + merge commits forbidden means a `develop -> main` merge stays permanently CONFLICTING.

Carries the root crate `armature-framework` at **0.4.0** (published to crates.io from a developer host, confirmed `max_stable: 0.4.0`) and the corrected `pre-push` hook from #281.

`v0.4.0` moves onto this commit once merged, so the tag describes the versions that actually shipped.