### PR TITLE
build: list armature-h1 in workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,13 @@
 [workspace]
 members = [
     "armature-log",
+    # Listed explicitly even though `armature-core`'s path dependency already
+    # pulls it into the workspace. Tooling that reads this list rather than
+    # `cargo metadata` cannot see an inferred member: `scripts/publish.sh`
+    # walks `members`, so it skipped `armature-h1` entirely and would have
+    # tried to publish `armature-core` against an `armature-h1` that was not
+    # on crates.io yet.
+    "armature-h1",
     "armature-core",
     "armature-proc-macro",
     "armature-graphql",


### PR DESCRIPTION
`armature-h1` reached the workspace only by inference: it is a path dependency of `armature-core`, which is enough for cargo but invisible to anything that reads the `members` array directly.

`scripts/publish.sh` is one of those things. It walks `members` to build the dependency-ordered publish list, so it never saw `armature-h1` and would have gone straight to `armature-core 0.8.0`, whose manifest requires `armature-h1 = "0.1"` — a crate that was not on crates.io at all. The publish would have failed partway through an otherwise ordered run. This was hit for real during the 0.8.0 release; `armature-h1 0.1.0` had to be published by hand first.

With it listed, the generated order puts `armature-h1` at 12 and `armature-core` at 15.

Verified with `cargo metadata`: 65 workspace packages, 64 listed members plus the root — nothing else is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)